### PR TITLE
Add stop/start charge services

### DIFF
--- a/custom_components/monta/services.yaml
+++ b/custom_components/monta/services.yaml
@@ -1,0 +1,15 @@
+start_charge:
+  target:
+    device:
+      integration: monta
+    entity:
+      integration: monta
+      domain: binary_sensor
+
+stop_charge:
+  target:
+    device:
+      integration: monta
+    entity:
+      integration: monta
+      domain: binary_sensor

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -14,5 +14,15 @@
             "connection": "Unable to connect to the server.",
             "unknown": "Unknown error occurred."
         }
+    },
+    "services": {
+        "start_charge": {
+            "description": "Start charge on selected charger",
+            "name": "Start Charge"
+        },
+        "stop_charge": {
+            "description": "Stop charge on selected charger.",
+            "name": "Stop Charge"
+        }
     }
 }


### PR DESCRIPTION
I've added these two services (which seems more normal to me). 

Primarily this is because my charger errors quite regularly due to high voltage problems (don't ask, it's a long story), and when that happens the switch goes unavailable. I have automation that alerts me if something goes unavailable, and this just nags at me. It is natural that it does become unavailable, when it can't be done, so not a complaint about your work.

You code style is better than mine, so feel free to improve if you decide to merge.