### PR TITLE
Indicate that entities have names so that core know to use it

### DIFF
--- a/custom_components/monta/entity.py
+++ b/custom_components/monta/entity.py
@@ -12,6 +12,7 @@ class MontaEntity(CoordinatorEntity[MontaDataUpdateCoordinator]):
     """MontaEntity class."""
 
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
 
     def __init__(
         self, coordinator: MontaDataUpdateCoordinator, charge_point_id: int


### PR DESCRIPTION
Indicate that entities have names so that core know to use device name when displaying

See here - https://developers.home-assistant.io/docs/core/entity#entity-naming