### PR TITLE
Add sensor for Last Charge

### DIFF
--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -1,19 +1,23 @@
 """Sensor platform for monta."""
 from __future__ import annotations
+
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
-from attr import dataclass
-
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity import generate_entity_id
+from dateutil import parser
 from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
-    SensorDeviceClass,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
 from .const import DOMAIN, ChargerStatus
 from .coordinator import MontaDataUpdateCoordinator
@@ -24,38 +28,89 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class MontaSensorEntityDescription(SensorEntityDescription):
-    """Describes a Monta sensor."""
+class MontaSensorEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[Any], StateType]
+    extra_state_attributes_fn: Callable[[Any], dict[str, str]] | None
 
 
-ENTITY_DESCRIPTIONS = (
-    SensorEntityDescription(
+@dataclass
+class MontaSensorEntityDescription(
+    SensorEntityDescription, MontaSensorEntityDescriptionMixin
+):
+    """Describes MontaSensor sensor entity."""
+
+
+def last_charge_state(data: dict[str, Any]) -> str:
+    """Process state for last charge (if available)."""
+    return data["charges"][0]["state"] if len(data["charges"]) > 0 else None
+
+
+def last_charge_extra_attributes(data: dict[str, Any]) -> dict[str, Any]:
+    """Process extra attributes for last charge (if available)."""
+    if len(data["charges"]) > 0:
+        attributes = data["charges"][0]
+        attributes["createdAt"] = _parse_date(attributes["createdAt"])
+        attributes["updatedAt"] = _parse_date(attributes["updatedAt"])
+        attributes["startedAt"] = _parse_date(attributes["startedAt"])
+        attributes["stoppedAt"] = _parse_date(attributes["stoppedAt"])
+        attributes["cablePluggedInAt"] = _parse_date(attributes["cablePluggedInAt"])
+        attributes["fullyChargedAt"] = _parse_date(attributes["fullyChargedAt"])
+        attributes["failedAt"] = _parse_date(attributes["failedAt"])
+        attributes["timeoutAt"] = _parse_date(attributes["timeoutAt"])
+        return attributes
+
+    return None
+
+
+def _parse_date(chargedate) -> str:
+    return parser.parse(chargedate) if chargedate else None
+
+
+ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
+    MontaSensorEntityDescription(
         key="charger_visibility",
         name="Visibility",
         icon="mdi:eye",
         device_class=SensorDeviceClass.ENUM,
         options=["public", "private"],
+        value_fn=lambda data: data["visibility"],
+        extra_state_attributes_fn=None,
     ),
-    SensorEntityDescription(
+    MontaSensorEntityDescription(
         key="charger_type",
         name="Type",
         icon="mdi:current-ac",
         device_class=SensorDeviceClass.ENUM,
         options=["ac", "dc"],
+        value_fn=lambda data: data["type"],
+        extra_state_attributes_fn=None,
     ),
-    SensorEntityDescription(
+    MontaSensorEntityDescription(
         key="charger_state",
         name="State",
         icon="mdi:state-machine",
         device_class=SensorDeviceClass.ENUM,
         options=[x.value for x in ChargerStatus],
+        value_fn=lambda data: data["state"],
+        extra_state_attributes_fn=None,
     ),
-    SensorEntityDescription(
+    MontaSensorEntityDescription(
         key="charger_lastMeterReadingKwh",
         name="Last meter reading",
         icon="mdi:counter",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement="kWh",
+        value_fn=lambda data: data["lastMeterReadingKwh"],
+        extra_state_attributes_fn=None,
+    ),
+    MontaSensorEntityDescription(
+        key="charge_startedAt",
+        name="Last Charge",
+        icon="mdi:ev-station",
+        value_fn=last_charge_state,
+        extra_state_attributes_fn=last_charge_extra_attributes,
     ),
 )
 
@@ -101,8 +156,22 @@ class MontaSensor(MontaEntity, SensorEntity):
         )
 
     @property
-    def native_value(self) -> str:
-        """Return the native value of the sensor."""
-        _, data_key = self.entity_description.key.split("charger_")
+    def native_value(self) -> StateType:
+        """Return the state."""
+        return self.entity_description.value_fn(
+            self.coordinator.data[self.charge_point_id]
+        )
 
-        return self.coordinator.data[self.charge_point_id].get(data_key)
+    @property
+    def extra_attributes(self) -> str:
+        """Return extra attributes for trhe sensor."""
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return the state attributes."""
+        if self.entity_description.extra_state_attributes_fn:
+            return self.entity_description.extra_state_attributes_fn(
+                self.coordinator.data[self.charge_point_id]
+            )
+        return None

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -1,7 +1,6 @@
 """Sensor platform for monta."""
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -23,9 +22,6 @@ from .const import DOMAIN, ChargerStatus
 from .coordinator import MontaDataUpdateCoordinator
 from .entity import MontaEntity
 from .utils import snake_case
-
-_LOGGER = logging.getLogger(__name__)
-
 
 @dataclass
 class MontaSensorEntityDescriptionMixin:
@@ -49,16 +45,23 @@ def last_charge_state(data: dict[str, Any]) -> str:
 
 def last_charge_extra_attributes(data: dict[str, Any]) -> dict[str, Any]:
     """Process extra attributes for last charge (if available)."""
-    if len(data["charges"]) > 0:
+    if data["charges"]:
         attributes = data["charges"][0]
-        attributes["createdAt"] = _parse_date(attributes["createdAt"])
-        attributes["updatedAt"] = _parse_date(attributes["updatedAt"])
-        attributes["startedAt"] = _parse_date(attributes["startedAt"])
-        attributes["stoppedAt"] = _parse_date(attributes["stoppedAt"])
-        attributes["cablePluggedInAt"] = _parse_date(attributes["cablePluggedInAt"])
-        attributes["fullyChargedAt"] = _parse_date(attributes["fullyChargedAt"])
-        attributes["failedAt"] = _parse_date(attributes["failedAt"])
-        attributes["timeoutAt"] = _parse_date(attributes["timeoutAt"])
+        date_keys = [
+            "createdAt",
+            "updatedAt",
+            "startedAt",
+            "stoppedAt",
+            "cablePluggedInAt",
+            "fullyChargedAt",
+            "failedAt",
+            "timeoutAt",
+        ]
+
+        for key in date_keys:
+            if key in attributes:
+                attributes[key] = _parse_date(attributes[key])
+
         return attributes
 
     return None

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -106,7 +106,7 @@ ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
         extra_state_attributes_fn=None,
     ),
     MontaSensorEntityDescription(
-        key="charge_startedAt",
+        key="charge_state",
         name="Last Charge",
         icon="mdi:ev-station",
         value_fn=last_charge_state,


### PR DESCRIPTION
This PR adds the retrieval of charge information for each charger, and creates a single sensor with information on the current/last charge (if available).

Since this adds an extra api call for each charger, if a significant number of chargers are being retrieved, it could extend the processing time for an update. I could add an options flow to the config flow, which optionally turns on this sensor if you would like. 

