### PR TITLE
Add wallet transactions

### DIFF
--- a/custom_components/monta/api.py
+++ b/custom_components/monta/api.py
@@ -18,7 +18,6 @@ from .const import (
     STORAGE_ACCESS_TOKEN,
     STORAGE_REFRESH_EXPIRE_TIME,
     STORAGE_REFRESH_TOKEN,
-    WALLET_TIMEDELTA,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -172,10 +171,9 @@ class MontaApiClient:
 
         access_token = await self.async_get_access_token()
 
-        trantime = (dt_util.utcnow() - WALLET_TIMEDELTA).strftime("%Y-%m-%dT%H:%M:%SZ")
         response = await self._api_wrapper(
             method="get",
-            path=f"wallet-transactions?fromDate={trantime}",
+            path="wallet-transactions",
             headers={"authorization": f"Bearer {access_token}"},
         )
 

--- a/custom_components/monta/api.py
+++ b/custom_components/monta/api.py
@@ -1,23 +1,23 @@
 """API module for monta."""
+
 from __future__ import annotations
 
 import asyncio
-import socket
 import logging
+import socket
 from datetime import timedelta
 
 import aiohttp
 import async_timeout
-
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    STORAGE_ACCESS_TOKEN,
-    STORAGE_ACCESS_EXPIRE_TIME,
-    STORAGE_REFRESH_TOKEN,
-    STORAGE_REFRESH_EXPIRE_TIME,
     PREEMPTIVE_REFRESH_TTL_IN_SECONDS,
+    STORAGE_ACCESS_EXPIRE_TIME,
+    STORAGE_ACCESS_TOKEN,
+    STORAGE_REFRESH_EXPIRE_TIME,
+    STORAGE_REFRESH_TOKEN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -114,7 +114,11 @@ class MontaApiClient:
             headers={"authorization": f"Bearer {access_token}"},
         )
 
-        return {item["id"]: item for item in response["data"] if item.get("serialNumber") is not None}
+        return {
+            item["id"]: item
+            for item in response["data"]
+            if item.get("serialNumber") is not None
+        }
 
     async def async_get_charges(self, charge_point_id: int) -> any:
         """Retrieve a list of charge."""

--- a/custom_components/monta/api.py
+++ b/custom_components/monta/api.py
@@ -105,7 +105,7 @@ class MontaApiClient:
         return response_json["accessToken"]
 
     async def async_get_charge_points(self) -> any:
-        """Get availbe charge points to the user."""
+        """Get available charge points to the user."""
 
         access_token = await self.async_get_access_token()
 
@@ -168,7 +168,7 @@ class MontaApiClient:
         return response
 
     async def async_get_wallet_transactions(self) -> any:
-        """Retrieve a list of charge."""
+        """Retrieve first page of wallet transations."""
 
         access_token = await self.async_get_access_token()
 

--- a/custom_components/monta/api.py
+++ b/custom_components/monta/api.py
@@ -167,7 +167,7 @@ class MontaApiClient:
         return response
 
     async def async_get_wallet_transactions(self) -> any:
-        """Retrieve first page of wallet transations."""
+        """Retrieve first page of wallet transactions."""
 
         access_token = await self.async_get_access_token()
 

--- a/custom_components/monta/api.py
+++ b/custom_components/monta/api.py
@@ -132,7 +132,7 @@ class MontaApiClient:
             headers={"authorization": f"Bearer {access_token}"},
         )
 
-        return sorted(response["data"], reverse=True, key=lambda charge: -charge["id"])
+        return sorted(response["data"], key=lambda charge: -charge["id"])
 
     async def async_start_charge(self, charge_point_id: int) -> any:
         """Start a charge."""
@@ -179,7 +179,7 @@ class MontaApiClient:
             headers={"authorization": f"Bearer {access_token}"},
         )
 
-        return sorted(response["data"], key=lambda charge: -charge["id"])
+        return sorted(response["data"], key=lambda transaction: -transaction["id"])
 
     async def async_get_access_token(self) -> str:
         """Get access token."""

--- a/custom_components/monta/api.py
+++ b/custom_components/monta/api.py
@@ -18,6 +18,7 @@ from .const import (
     STORAGE_ACCESS_TOKEN,
     STORAGE_REFRESH_EXPIRE_TIME,
     STORAGE_REFRESH_TOKEN,
+    WALLET_TIMEDELTA,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -131,7 +132,7 @@ class MontaApiClient:
             headers={"authorization": f"Bearer {access_token}"},
         )
 
-        return sorted(response["data"], key=lambda charge: -charge["id"])
+        return sorted(response["data"], reverse=True, key=lambda charge: -charge["id"])
 
     async def async_start_charge(self, charge_point_id: int) -> any:
         """Start a charge."""
@@ -165,6 +166,20 @@ class MontaApiClient:
         _LOGGER.debug("Stopped charge for chargeId: %s <%s>", charge_id, response)
 
         return response
+
+    async def async_get_wallet_transactions(self) -> any:
+        """Retrieve a list of charge."""
+
+        access_token = await self.async_get_access_token()
+
+        trantime = (dt_util.utcnow() - WALLET_TIMEDELTA).strftime("%Y-%m-%dT%H:%M:%SZ")
+        response = await self._api_wrapper(
+            method="get",
+            path=f"wallet-transactions?fromDate={trantime}",
+            headers={"authorization": f"Bearer {access_token}"},
+        )
+
+        return sorted(response["data"], key=lambda charge: -charge["id"])
 
     async def async_get_access_token(self) -> str:
         """Get access token."""

--- a/custom_components/monta/binary_sensor.py
+++ b/custom_components/monta/binary_sensor.py
@@ -1,4 +1,5 @@
 """Binary sensor platform for monta."""
+
 from __future__ import annotations
 
 import logging
@@ -9,7 +10,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-
 from homeassistant.helpers.entity import generate_entity_id
 
 from .const import DOMAIN

--- a/custom_components/monta/binary_sensor.py
+++ b/custom_components/monta/binary_sensor.py
@@ -32,7 +32,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
     """Set up the binary_sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS].keys():
+    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS]:
         async_add_devices(
             [
                 MontaBinarySensor(

--- a/custom_components/monta/binary_sensor.py
+++ b/custom_components/monta/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.helpers.entity import generate_entity_id
 
-from .const import DOMAIN
+from .const import ATTR_CHARGEPOINTS, DOMAIN
 from .coordinator import MontaDataUpdateCoordinator
 from .entity import MontaEntity
 from .utils import snake_case
@@ -32,7 +32,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
     """Set up the binary_sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    for charge_point_id, _ in coordinator.data.items():
+    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS].keys():
         async_add_devices(
             [
                 MontaBinarySensor(
@@ -67,6 +67,6 @@ class MontaBinarySensor(MontaEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary_sensor is on."""
-        return self.coordinator.data[self.charge_point_id].get(
+        return self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id].get(
             self.entity_description.key, False
         )

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -1,7 +1,6 @@
 """Constants for monta."""
 
 import enum
-from datetime import timedelta
 from logging import Logger, getLogger
 
 LOGGER: Logger = getLogger(__package__)
@@ -21,8 +20,6 @@ STORAGE_ACCESS_EXPIRE_TIME = "access_expire_time"
 STORAGE_ACCESS_TOKEN = "access_token"
 STORAGE_REFRESH_TOKEN = "refresh_token"
 STORAGE_REFRESH_EXPIRE_TIME = "refresh_expire_time"
-
-WALLET_TIMEDELTA = timedelta(days=7)
 
 
 class ChargerStatus(enum.StrEnum):

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -11,7 +11,7 @@ DOMAIN = "monta"
 VERSION = "0.0.0"
 ATTRIBUTION = "Data provided by https://docs.public-api.monta.com"
 
-ATTR_CHARGEPOINTS = "chargepoints"
+ATTR_CHARGE_POINTS = "charge_points"
 ATTR_WALLET = "wallet"
 
 PREEMPTIVE_REFRESH_TTL_IN_SECONDS = 300

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -1,4 +1,5 @@
 """Constants for monta."""
+
 import enum
 from logging import Logger, getLogger
 

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -1,6 +1,7 @@
 """Constants for monta."""
 
 import enum
+from datetime import timedelta
 from logging import Logger, getLogger
 
 LOGGER: Logger = getLogger(__package__)
@@ -10,6 +11,9 @@ DOMAIN = "monta"
 VERSION = "0.0.0"
 ATTRIBUTION = "Data provided by https://docs.public-api.monta.com"
 
+ATTR_CHARGEPOINTS = "chargepoints"
+ATTR_WALLET = "wallet"
+
 PREEMPTIVE_REFRESH_TTL_IN_SECONDS = 300
 STORAGE_KEY = "monta_auth"
 STORAGE_VERSION = 1
@@ -17,6 +21,8 @@ STORAGE_ACCESS_EXPIRE_TIME = "access_expire_time"
 STORAGE_ACCESS_TOKEN = "access_token"
 STORAGE_REFRESH_TOKEN = "refresh_token"
 STORAGE_REFRESH_EXPIRE_TIME = "refresh_expire_time"
+
+WALLET_TIMEDELTA = timedelta(days=7)
 
 
 class ChargerStatus(enum.StrEnum):
@@ -34,3 +40,13 @@ class ChargerStatus(enum.StrEnum):
     DISCONNECTED = "disconnected"
     PASSIVE = "passive"
     OTHER = "other"
+
+
+class WalletStatus(enum.StrEnum):
+    """Wallet Status Description."""
+
+    COMPLETE = "complete"
+    FAILED = "failed"
+    PENDING = "pending"
+    RESERVED = "reserved"
+    NONE = "none"

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -1,4 +1,5 @@
 """DataUpdateCoordinator for monta."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import MontaApiClient, MontaApiClientAuthenticationError, MontaApiClientError
-from .const import ATTR_CHARGEPOINTS, ATTR_WALLET, DOMAIN, LOGGER
+from .const import ATTR_charge_points, ATTR_WALLET, DOMAIN, LOGGER
 
 
 # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
@@ -32,13 +32,13 @@ class MontaDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            chargepoints = await self.client.async_get_charge_points()
-            for charge_point_id in chargepoints:
-                chargepoints[charge_point_id][
+            charge_points = await self.client.async_get_charge_points()
+            for charge_point_id in charge_points:
+                charge_points[charge_point_id][
                     "charges"
                 ] = await self.client.async_get_charges(charge_point_id)
             wallet = await self.client.async_get_wallet_transactions()
-            return {ATTR_CHARGEPOINTS: chargepoints, ATTR_WALLET: wallet}
+            return {ATTR_charge_points: charge_points, ATTR_WALLET: wallet}
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except MontaApiClientError as exception:

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -33,7 +33,7 @@ class MontaDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         try:
             chargepoints = await self.client.async_get_charge_points()
-            for charge_point_id in chargepoints.keys():
+            for charge_point_id in chargepoints:
                 chargepoints[charge_point_id][
                     "charges"
                 ] = await self.client.async_get_charges(charge_point_id)

--- a/custom_components/monta/entity.py
+++ b/custom_components/monta/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DOMAIN
+from .const import ATTR_CHARGEPOINTS, ATTRIBUTION, DOMAIN
 from .coordinator import MontaDataUpdateCoordinator
 
 
@@ -25,6 +25,7 @@ class MontaEntity(CoordinatorEntity[MontaDataUpdateCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this Wallbox device."""
+        chargepoint = self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id]
         return DeviceInfo(
             identifiers={
                 (
@@ -32,8 +33,8 @@ class MontaEntity(CoordinatorEntity[MontaDataUpdateCoordinator]):
                     self.charge_point_id,
                 )
             },
-            name=f"Monta - {self.coordinator.data[self.charge_point_id]['name']}",
-            manufacturer=self.coordinator.data[self.charge_point_id]["brandName"],
-            model=self.coordinator.data[self.charge_point_id]["modelName"],
-            sw_version=self.coordinator.data[self.charge_point_id]["firmwareVersion"],
+            name=f"Monta - {chargepoint['name']}",
+            manufacturer=chargepoint["brandName"],
+            model=chargepoint["modelName"],
+            sw_version=chargepoint["firmwareVersion"],
         )

--- a/custom_components/monta/entity.py
+++ b/custom_components/monta/entity.py
@@ -1,4 +1,5 @@
 """MontaEntity class."""
+
 from __future__ import annotations
 
 from homeassistant.helpers.entity import DeviceInfo

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -1,12 +1,13 @@
 """Sensor platform for monta."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from dateutil import parser
-from datetime import datetime
 from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,
     SensorDeviceClass,

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    ATTR_CHARGEPOINTS,
+    ATTR_CHARGE_POINTS,
     ATTR_WALLET,
     ATTRIBUTION,
     DOMAIN,
@@ -34,7 +34,7 @@ from .coordinator import MontaDataUpdateCoordinator
 from .entity import MontaEntity
 from .utils import snake_case
 
-CHARGEPOINTDATEKEYS = [
+CHARGE_POINT_DATE_KEYS = [
     "createdAt",
     "updatedAt",
     "startedAt",
@@ -44,7 +44,7 @@ CHARGEPOINTDATEKEYS = [
     "failedAt",
     "timeoutAt",
 ]
-WALLETDATEKEYS = [
+WALLET_DATE_KEYS = [
     "createdAt",
     "updatedAt",
     "completedAt",
@@ -79,7 +79,7 @@ def last_charge_extra_attributes(data: dict[str, Any]) -> dict[str, Any]:
     """Process extra attributes for last charge (if available)."""
     if data["charges"]:
         attributes = data["charges"][0]
-        for key in CHARGEPOINTDATEKEYS:
+        for key in CHARGE_POINT_DATE_KEYS:
             if key in attributes:
                 attributes[key] = _parse_date(attributes[key])
 
@@ -94,7 +94,7 @@ def wallet_extra_attributes(data: list[dict[str, Any]]) -> dict[str, Any]:
 
     if data:
         for transaction in data:
-            for key in WALLETDATEKEYS:
+            for key in WALLET_DATE_KEYS:
                 if key in transaction:
                     transaction[key] = _parse_date(transaction[key])
         attributes["transactions"] = data
@@ -112,7 +112,7 @@ def _parse_date(chargedate: str):
     return None
 
 
-CHARGEPOINT_ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
+CHARGE_POINT_ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
     MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
         key="charger_visibility",
         name="Visibility",
@@ -175,16 +175,16 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS]:
+    for charge_point_id in coordinator.data[ATTR_CHARGE_POINTS]:
         async_add_entities(
             [
-                MontaChargepointSensor(
+                MontaChargePointSensor(
                     coordinator,
                     entry,
                     description,
                     charge_point_id,
                 )
-                for description in CHARGEPOINT_ENTITY_DESCRIPTIONS
+                for description in CHARGE_POINT_ENTITY_DESCRIPTIONS
             ]
         )
     async_add_entities(
@@ -199,7 +199,7 @@ async def async_setup_entry(
     )
 
 
-class MontaChargepointSensor(MontaEntity, SensorEntity):
+class MontaChargePointSensor(MontaEntity, SensorEntity):
     """monta Sensor class."""
 
     def __init__(
@@ -223,12 +223,12 @@ class MontaChargepointSensor(MontaEntity, SensorEntity):
     def native_value(self) -> StateType:
         """Return the state."""
         return self.entity_description.value_fn(
-            self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id]
+            self.coordinator.data[ATTR_CHARGE_POINTS][self.charge_point_id]
         )
 
     @property
     def extra_attributes(self) -> str:
-        """Return extra attributes for trhe sensor."""
+        """Return extra attributes for the sensor."""
         return None
 
     @property
@@ -236,7 +236,7 @@ class MontaChargepointSensor(MontaEntity, SensorEntity):
         """Return the state attributes."""
         if self.entity_description.extra_state_attributes_fn:
             return self.entity_description.extra_state_attributes_fn(
-                self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id]
+                self.coordinator.data[ATTR_CHARGE_POINTS][self.charge_point_id]
             )
         return None
 
@@ -270,7 +270,7 @@ class MontaWalletSensor(CoordinatorEntity[MontaDataUpdateCoordinator], SensorEnt
 
     @property
     def extra_attributes(self) -> str:
-        """Return extra attributes for trhe sensor."""
+        """Return extra attributes for the sensor."""
         return None
 
     @property

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -19,11 +19,36 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, ChargerStatus
+from .const import (
+    ATTR_CHARGEPOINTS,
+    ATTR_WALLET,
+    ATTRIBUTION,
+    DOMAIN,
+    WALLET_TIMEDELTA,
+    ChargerStatus,
+    WalletStatus,
+)
 from .coordinator import MontaDataUpdateCoordinator
 from .entity import MontaEntity
 from .utils import snake_case
+
+CHARGEPOINTDATEKEYS = [
+    "createdAt",
+    "updatedAt",
+    "startedAt",
+    "stoppedAt",
+    "cablePluggedInAt",
+    "fullyChargedAt",
+    "failedAt",
+    "timeoutAt",
+]
+WALLETDATEKEYS = [
+    "createdAt",
+    "updatedAt",
+    "completedAt",
+]
 
 
 @dataclass
@@ -41,6 +66,10 @@ class MontaSensorEntityDescription(
     """Describes MontaSensor sensor entity."""
 
 
+def _days_hours_minutes(td):
+    return f"{td.days} days, {td.seconds//3600} hours, {(td.seconds//60)%60} minutes"
+
+
 def last_charge_state(data: dict[str, Any]) -> str:
     """Process state for last charge (if available)."""
     return data["charges"][0]["state"] if len(data["charges"]) > 0 else None
@@ -50,18 +79,7 @@ def last_charge_extra_attributes(data: dict[str, Any]) -> dict[str, Any]:
     """Process extra attributes for last charge (if available)."""
     if data["charges"]:
         attributes = data["charges"][0]
-        date_keys = [
-            "createdAt",
-            "updatedAt",
-            "startedAt",
-            "stoppedAt",
-            "cablePluggedInAt",
-            "fullyChargedAt",
-            "failedAt",
-            "timeoutAt",
-        ]
-
-        for key in date_keys:
+        for key in CHARGEPOINTDATEKEYS:
             if key in attributes:
                 attributes[key] = _parse_date(attributes[key])
 
@@ -70,17 +88,32 @@ def last_charge_extra_attributes(data: dict[str, Any]) -> dict[str, Any]:
     return None
 
 
+def wallet_extra_attributes(data: list[dict[str, Any]]) -> dict[str, Any]:
+    """Process extra attributes for the wallet (if available)."""
+    attributes = {"period_retrieved": _days_hours_minutes(WALLET_TIMEDELTA)}
+
+    if data:
+        for transaction in data:
+            for key in WALLETDATEKEYS:
+                if key in transaction:
+                    transaction[key] = _parse_date(transaction[key])
+        attributes["transactions"] = data
+
+    return attributes
+
+
 def _parse_date(chargedate: str):
     if isinstance(chargedate, str):
         return parser.parse(chargedate)
-    elif isinstance(chargedate, datetime):
+
+    if isinstance(chargedate, datetime):
         return chargedate
-    else:
-        return None
+
+    return None
 
 
-ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
-    MontaSensorEntityDescription(
+CHARGEPOINT_ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
         key="charger_visibility",
         name="Visibility",
         icon="mdi:eye",
@@ -89,7 +122,7 @@ ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
         value_fn=lambda data: data["visibility"],
         extra_state_attributes_fn=None,
     ),
-    MontaSensorEntityDescription(
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
         key="charger_type",
         name="Type",
         icon="mdi:current-ac",
@@ -98,7 +131,7 @@ ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
         value_fn=lambda data: data["type"],
         extra_state_attributes_fn=None,
     ),
-    MontaSensorEntityDescription(
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
         key="charger_state",
         name="State",
         icon="mdi:state-machine",
@@ -107,21 +140,31 @@ ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
         value_fn=lambda data: data["state"],
         extra_state_attributes_fn=None,
     ),
-    MontaSensorEntityDescription(
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
         key="charger_lastMeterReadingKwh",
         name="Last meter reading",
-        icon="mdi:counter",
-        device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement="kWh",
+        icon="mdi:wallet",
         value_fn=lambda data: data["lastMeterReadingKwh"],
         extra_state_attributes_fn=None,
     ),
-    MontaSensorEntityDescription(
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
         key="charge_state",
         name="Last Charge",
         icon="mdi:ev-station",
         value_fn=last_charge_state,
         extra_state_attributes_fn=last_charge_extra_attributes,
+    ),
+)
+
+WALLET_ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
+        key="monta-personal-wallet",
+        name="Monta - Personal Wallet",
+        icon="mdi:eye",
+        device_class=SensorDeviceClass.ENUM,
+        options=[x.value for x in WalletStatus],
+        value_fn=lambda data: data[0]["state"] if data else "none",
+        extra_state_attributes_fn=wallet_extra_attributes,
     ),
 )
 
@@ -132,21 +175,31 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    for charge_point_id, _ in coordinator.data.items():
+    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS].keys():
         async_add_entities(
             [
-                MontaSensor(
+                MontaChargepointSensor(
                     coordinator,
                     entry,
                     description,
                     charge_point_id,
                 )
-                for description in ENTITY_DESCRIPTIONS
+                for description in CHARGEPOINT_ENTITY_DESCRIPTIONS
             ]
         )
+    async_add_entities(
+        [
+            MontaWalletSensor(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in WALLET_ENTITY_DESCRIPTIONS
+        ]
+    )
 
 
-class MontaSensor(MontaEntity, SensorEntity):
+class MontaChargepointSensor(MontaEntity, SensorEntity):
     """monta Sensor class."""
 
     def __init__(
@@ -170,7 +223,7 @@ class MontaSensor(MontaEntity, SensorEntity):
     def native_value(self) -> StateType:
         """Return the state."""
         return self.entity_description.value_fn(
-            self.coordinator.data[self.charge_point_id]
+            self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id]
         )
 
     @property
@@ -183,6 +236,48 @@ class MontaSensor(MontaEntity, SensorEntity):
         """Return the state attributes."""
         if self.entity_description.extra_state_attributes_fn:
             return self.entity_description.extra_state_attributes_fn(
-                self.coordinator.data[self.charge_point_id]
+                self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id]
+            )
+        return None
+
+
+class MontaWalletSensor(CoordinatorEntity[MontaDataUpdateCoordinator], SensorEntity):
+    """monta Sensor class."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: MontaDataUpdateCoordinator,
+        _: ConfigEntry,
+        entity_description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor class."""
+        super().__init__(coordinator)
+
+        self.entity_description = entity_description
+        self._attr_unique_id = generate_entity_id(
+            ENTITY_ID_FORMAT,
+            f"monta_{snake_case(entity_description.key)}",
+            "personal_monta_wallet",
+        )
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state."""
+        return self.entity_description.value_fn(self.coordinator.data[ATTR_WALLET])
+
+    @property
+    def extra_attributes(self) -> str:
+        """Return extra attributes for trhe sensor."""
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return the state attributes."""
+        if self.entity_description.extra_state_attributes_fn:
+            return self.entity_description.extra_state_attributes_fn(
+                self.coordinator.data[ATTR_WALLET]
             )
         return None

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -26,7 +26,6 @@ from .const import (
     ATTR_WALLET,
     ATTRIBUTION,
     DOMAIN,
-    WALLET_TIMEDELTA,
     ChargerStatus,
     WalletStatus,
 )
@@ -90,7 +89,7 @@ def last_charge_extra_attributes(data: dict[str, Any]) -> dict[str, Any]:
 
 def wallet_extra_attributes(data: list[dict[str, Any]]) -> dict[str, Any]:
     """Process extra attributes for the wallet (if available)."""
-    attributes = {"period_retrieved": _days_hours_minutes(WALLET_TIMEDELTA)}
+    attributes = {}
 
     if data:
         for transaction in data:

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -175,7 +175,7 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS].keys():
+    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS]:
         async_add_entities(
             [
                 MontaChargepointSensor(

--- a/custom_components/monta/services.py
+++ b/custom_components/monta/services.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 
-from .const import DOMAIN
+from .const import ATTR_CHARGEPOINTS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,9 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         charge_point_id = service_call.data["charge_point_id"]
         _LOGGER.debug("Called stop charging for %s", charge_point_id)
 
-        if coordinator.data[charge_point_id]["state"].startswith("busy"):
+        if coordinator.data[ATTR_CHARGEPOINTS][charge_point_id]["state"].startswith(
+            "busy"
+        ):
             await coordinator.async_stop_charge(charge_point_id)
             return
 
@@ -37,7 +39,7 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         charge_point_id = service_call.data["charge_point_id"]
         _LOGGER.debug("Called start charging for %s", charge_point_id)
 
-        if coordinator.data[charge_point_id]["state"] == "available":
+        if coordinator.data[ATTR_CHARGEPOINTS][charge_point_id]["state"] == "available":
             await coordinator.async_start_charge(charge_point_id)
             return
 

--- a/custom_components/monta/switch.py
+++ b/custom_components/monta/switch.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS].keys():
+    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS]:
         async_add_devices(
             [
                 MontaSwitch(

--- a/custom_components/monta/switch.py
+++ b/custom_components/monta/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for monta."""
+
 from __future__ import annotations
 
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT,
     SwitchEntity,
@@ -10,6 +10,7 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, ChargerStatus
 from .coordinator import MontaDataUpdateCoordinator

--- a/custom_components/monta/switch.py
+++ b/custom_components/monta/switch.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, ChargerStatus
+from .const import ATTR_CHARGEPOINTS, DOMAIN, ChargerStatus
 from .coordinator import MontaDataUpdateCoordinator
 from .entity import MontaEntity
 from .utils import snake_case
@@ -31,7 +31,7 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    for charge_point_id, _ in coordinator.data.items():
+    for charge_point_id in coordinator.data[ATTR_CHARGEPOINTS].keys():
         async_add_devices(
             [
                 MontaSwitch(
@@ -65,7 +65,9 @@ class MontaSwitch(MontaEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return the availability of the switch."""
-        return self.coordinator.data[self.charge_point_id]["state"] not in {
+        return self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id][
+            "state"
+        ] not in {
             ChargerStatus.DISCONNECTED,
             ChargerStatus.ERROR,
         }
@@ -73,7 +75,9 @@ class MontaSwitch(MontaEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the status of pause/resume."""
-        return self.coordinator.data[self.charge_point_id]["state"] in {
+        return self.coordinator.data[ATTR_CHARGEPOINTS][self.charge_point_id][
+            "state"
+        ] in {
             ChargerStatus.BUSY_CHARGING,
             ChargerStatus.BUSY,
             ChargerStatus.BUSY_SCHEDULED,


### PR DESCRIPTION
I had a couple of old transactions in my personal wallet, so I've added the api call and setup to create a personal wallet sensor. Currently this is set to retrieve the last 7 days, but potentially that could be configureable.

Not sure if there are other wallets it could retrieve, it certainly doesn't retrieve data from my enterprise team wallet.

I split this into two commits because my dev environment is setup using standard HA dev container which automatically does some formatting. The first commit makes no code changes, it is just formatting.