### PR TITLE
Add required device class and UOM to last meter reading

### DIFF
--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -15,6 +15,9 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfEnergy,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -143,6 +146,8 @@ CHARGE_POINT_ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
         key="charger_lastMeterReadingKwh",
         name="Last meter reading",
         icon="mdi:wallet",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         value_fn=lambda data: data["lastMeterReadingKwh"],
         extra_state_attributes_fn=None,
     ),


### PR DESCRIPTION
The entity was showing an error in my energy dashboard