### PR TITLE
Configurable update Interval and options improvement

### DIFF
--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import MontaApiClient
-from .const import DOMAIN, STORAGE_KEY, STORAGE_VERSION
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, STORAGE_KEY, STORAGE_VERSION
 from .coordinator import MontaDataUpdateCoordinator
 from .services import async_setup_services
 
@@ -31,6 +31,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
     await store.async_remove()
 
+    # Get scan interval from options or data, with default fallback
+    scan_interval = entry.options.get(
+        CONF_SCAN_INTERVAL,
+        entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+    )
+
     hass.data[DOMAIN][entry.entry_id] = coordinator = MontaDataUpdateCoordinator(
         hass=hass,
         client=MontaApiClient(
@@ -39,6 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             session=async_get_clientsession(hass),
             store=store,
         ),
+        scan_interval=scan_interval,
     )
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -111,13 +111,70 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict | None = None
     ) -> config_entries.FlowResult:
         """Manage the options."""
+        _errors = {}
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            # Only validate credentials if they were changed
+            if (
+                user_input.get(CONF_CLIENT_ID) != self.config_entry.data.get(CONF_CLIENT_ID)
+                or user_input.get(CONF_CLIENT_SECRET) != self.config_entry.data.get(CONF_CLIENT_SECRET)
+            ):
+                try:
+                    await self._test_credentials(
+                        client_id=user_input[CONF_CLIENT_ID],
+                        client_secret=user_input[CONF_CLIENT_SECRET],
+                    )
+                except MontaApiClientAuthenticationError as exception:
+                    LOGGER.warning(exception)
+                    _errors["base"] = "auth"
+                except MontaApiClientCommunicationError as exception:
+                    LOGGER.error(exception)
+                    _errors["base"] = "connection"
+                except MontaApiClientError as exception:
+                    LOGGER.exception(exception)
+                    _errors["base"] = "unknown"
+
+            if not _errors:
+                # Update the config entry data with new credentials if they changed
+                if (
+                    user_input.get(CONF_CLIENT_ID) != self.config_entry.data.get(CONF_CLIENT_ID)
+                    or user_input.get(CONF_CLIENT_SECRET) != self.config_entry.data.get(CONF_CLIENT_SECRET)
+                ):
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data={
+                            CONF_CLIENT_ID: user_input[CONF_CLIENT_ID],
+                            CONF_CLIENT_SECRET: user_input[CONF_CLIENT_SECRET],
+                            CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                        },
+                    )
+                return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
+                    vol.Required(
+                        CONF_CLIENT_ID,
+                        default=(user_input or {}).get(
+                            CONF_CLIENT_ID,
+                            self.config_entry.data.get(CONF_CLIENT_ID),
+                        ),
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT
+                        ),
+                    ),
+                    vol.Required(
+                        CONF_CLIENT_SECRET,
+                        default=(user_input or {}).get(
+                            CONF_CLIENT_SECRET,
+                            self.config_entry.data.get(CONF_CLIENT_SECRET),
+                        ),
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD
+                        ),
+                    ),
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
                         default=self.config_entry.options.get(
@@ -134,4 +191,15 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                 }
             ),
+            errors=_errors,
         )
+
+    async def _test_credentials(self, client_id: str, client_secret: str) -> any:
+        """Validate credentials."""
+        client = MontaApiClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            session=async_create_clientsession(self.hass),
+            store=Store(self.hass, STORAGE_VERSION, STORAGE_KEY),
+        )
+        return await client.async_request_token()

--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -14,7 +14,7 @@ from .api import (
     MontaApiClientCommunicationError,
     MontaApiClientError,
 )
-from .const import DOMAIN, LOGGER, STORAGE_KEY, STORAGE_VERSION
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, STORAGE_KEY, STORAGE_VERSION
 
 
 class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -66,10 +66,28 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                             type=selector.TextSelectorType.PASSWORD
                         ),
                     ),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        default=(user_input or {}).get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=3600,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
                 }
             ),
             errors=_errors,
         )
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Get the options flow for this handler."""
+        return MontaOptionsFlowHandler(config_entry)
 
     async def _test_credentials(self, client_id: str, client_secret: str) -> any:
         """Validate credentials."""
@@ -80,3 +98,40 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             store=Store(self.hass, STORAGE_VERSION, STORAGE_KEY),
         )
         return await client.async_request_token()
+
+
+class MontaOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow for Monta."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict | None = None
+    ) -> config_entries.FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL,
+                            self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=3600,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
+                }
+            ),
+        )

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -14,6 +14,9 @@ ATTR_CHARGE_POINTS = "charge_points"
 ATTR_WALLET = "wallet"
 ATTR_TRANSACTIONS = "transactions"
 
+CONF_SCAN_INTERVAL = "scan_interval"
+DEFAULT_SCAN_INTERVAL = 120  # Default to 120 seconds to stay within rate limits
+
 PREEMPTIVE_REFRESH_TTL_IN_SECONDS = 300
 STORAGE_KEY = "monta_auth"
 STORAGE_VERSION = 1

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -18,14 +18,16 @@ class MontaDataUpdateCoordinator(DataUpdateCoordinator):
 
     config_entry: ConfigEntry
 
-    def __init__(self, hass: HomeAssistant, client: MontaApiClient) -> None:
+    def __init__(
+        self, hass: HomeAssistant, client: MontaApiClient, scan_interval: int
+    ) -> None:
         """Initialize."""
         self.client = client
         super().__init__(
             hass=hass,
             logger=LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=30),
+            update_interval=timedelta(seconds=scan_interval),
         )
 
     async def _async_update_data(self):

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -5,7 +5,11 @@
 				"description": "👉 Monta Public API is in BETA currently.\nIn order to obtain client id/Client secret to it, you might have to opt-in to their Beta program. This can be done in your user account settings in the app or in Monta's CPMS. \n\nClient id and secret are obtained from https://portal2.monta.app/applications.",
 				"data": {
 					"client_id": "Client id",
-					"client_secret": "client secret"
+					"client_secret": "client secret",
+					"scan_interval": "Scan interval (seconds)"
+				},
+				"data_description": {
+					"scan_interval": "How often to fetch data from Monta API. Monta has a rate limit of 10 requests per minute. Recommended: 120 seconds or higher for multiple chargers."
 				}
 			}
 		},
@@ -13,6 +17,19 @@
 			"auth": "Client id/client secret is wrong.",
 			"connection": "Unable to connect to the server.",
 			"unknown": "Unknown error occurred."
+		}
+	},
+	"options": {
+		"step": {
+			"init": {
+				"description": "Configure Monta integration options",
+				"data": {
+					"scan_interval": "Scan interval (seconds)"
+				},
+				"data_description": {
+					"scan_interval": "How often to fetch data from Monta API. Monta has a rate limit of 10 requests per minute. Recommended: 120 seconds or higher for multiple chargers."
+				}
+			}
 		}
 	},
 	"services": {

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -22,11 +22,15 @@
 	"options": {
 		"step": {
 			"init": {
-				"description": "Configure Monta integration options",
+				"description": "Configure Monta integration options. You can update your credentials or adjust the scan interval here.",
 				"data": {
+					"client_id": "Client id",
+					"client_secret": "Client secret",
 					"scan_interval": "Scan interval (seconds)"
 				},
 				"data_description": {
+					"client_id": "Your Monta API client ID from https://portal2.monta.app/applications",
+					"client_secret": "Your Monta API client secret from https://portal2.monta.app/applications",
 					"scan_interval": "How often to fetch data from Monta API. Monta has a rate limit of 10 requests per minute. Recommended: 120 seconds or higher for multiple chargers."
 				}
 			}

--- a/custom_components/monta/translations/pt.json
+++ b/custom_components/monta/translations/pt.json
@@ -22,11 +22,15 @@
   "options": {
     "step": {
       "init": {
-        "description": "Configurar opções de integração Monta",
+        "description": "Configurar opções de integração Monta. Você pode atualizar suas credenciais ou ajustar o intervalo de varredura aqui.",
         "data": {
+          "client_id": "ID do cliente",
+          "client_secret": "Segredo do cliente",
           "scan_interval": "Intervalo de varredura (segundos)"
         },
         "data_description": {
+          "client_id": "Seu ID de cliente da API Monta de https://portal2.monta.app/applications",
+          "client_secret": "Seu segredo de cliente da API Monta de https://portal2.monta.app/applications",
           "scan_interval": "Com que frequência buscar dados da API Monta. A Monta tem um limite de 10 solicitações por minuto. Recomendado: 120 segundos ou mais para vários carregadores."
         }
       }

--- a/custom_components/monta/translations/pt.json
+++ b/custom_components/monta/translations/pt.json
@@ -5,7 +5,11 @@
         "description": "👉 A API Pública da Monta está atualmente em BETA.\nPara obter o ID do cliente/segredo do cliente, pode ser necessário aderir ao programa Beta. Isto pode ser feito nas configurações da sua conta de utilizador na aplicação ou no CPMS da Monta.\n\nO ID e o segredo do cliente são obtidos em https://portal2.monta.app/applications.",
         "data": {
           "client_id": "ID do cliente",
-          "client_secret": "Segredo do cliente"
+          "client_secret": "Segredo do cliente",
+          "scan_interval": "Intervalo de varredura (segundos)"
+        },
+        "data_description": {
+          "scan_interval": "Com que frequência buscar dados da API Monta. A Monta tem um limite de 10 solicitações por minuto. Recomendado: 120 segundos ou mais para vários carregadores."
         }
       }
     },
@@ -13,6 +17,19 @@
       "auth": "ID do cliente/segredo do cliente está incorreto.",
       "connection": "Não foi possível ligar ao servidor.",
       "unknown": "Ocorreu um erro desconhecido."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Configurar opções de integração Monta",
+        "data": {
+          "scan_interval": "Intervalo de varredura (segundos)"
+        },
+        "data_description": {
+          "scan_interval": "Com que frequência buscar dados da API Monta. A Monta tem um limite de 10 solicitações por minuto. Recomendado: 120 segundos ou mais para vários carregadores."
+        }
+      }
     }
   },
   "services": {


### PR DESCRIPTION
#### Add Configurable Scan Interval and Options Flow for Credentials Update

**Problem**
Monta has started enforcing API rate limits of 10 requests per minute (see [Monta API Integration Notes](https://docs.public-api.monta.com/reference/integration-notes)). The integration was previously hardcoded to poll every 30 seconds, which causes issues for users with multiple charge points:

**Example**: With 3 charge points and a 30-second interval:
- Each poll makes: 1 (charge points) + 3 (charges per charger) + 1 (wallet) + 1 (transactions) = ~6 requests
- Requests per minute: (60/30) × 6 = 12 requests/minute
- Result: Rate limit exceeded

Additionally, users had no way to update their API credentials without completely removing and reinstalling the integration.

**Solution**
This PR implements two key improvements:

1. Configurable Scan Interval
	- Default interval: 120 seconds (safe for most users with multiple chargers)
	- Configurable range: 30-3600 seconds
	- Set during setup: Users can configure the interval when initially adding the integration
	- Adjustable anytime: Can be changed via the integration's options menu
	
	With 120-second interval and 3 chargers:
		- Requests per minute: (60/120) × 6 = 3 requests/minute
		- Result: Well within rate limits ✅

2. Options Flow for Full Reconfiguration
 - Users can now update all integration settings without reinstalling



**For new installations:**
1. Add Monta integration
2. Enter Client ID and Client Secret
3. Optionally adjust scan interval (defaults to 120 seconds)

**For existing installations:**
1. Go to Settings → Devices & Services → Monta
2. Click "⚙️"
3. Update credentials and/or scan interval as needed
4. Save - integration reloads automatically

**Recommendations:**

- Single charger: 60-120 seconds
- Multiple chargers: 120-180 seconds or higher
- Many chargers (5+): 300+ seconds

**Testing Checklist**
- [ ] Fresh installation with custom scan interval
- [ ] Fresh installation with default scan interval (120s)
- [ ] Update scan interval via options flow
- [ ] Update credentials via options flow
- [ ] Verify credential validation on invalid credentials
- [ ] Confirm integration reloads after options update
- [ ] Test with multiple charge points to ensure rate limit compliance
