### PR TITLE
Add variable scan intervals for different API endpoints

### DIFF
--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -13,11 +13,9 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import MontaApiClient
 from .const import (
-    CONF_SCAN_INTERVAL,
     CONF_SCAN_INTERVAL_CHARGE_POINTS,
     CONF_SCAN_INTERVAL_WALLET,
     CONF_SCAN_INTERVAL_TRANSACTIONS,
-    DEFAULT_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
     DEFAULT_SCAN_INTERVAL_WALLET,
     DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
@@ -25,7 +23,11 @@ from .const import (
     STORAGE_KEY,
     STORAGE_VERSION,
 )
-from .coordinator import MontaDataUpdateCoordinator
+from .coordinator import (
+    MontaChargePointCoordinator,
+    MontaWalletCoordinator,
+    MontaTransactionCoordinator,
+)
 from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [
@@ -43,12 +45,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
     await store.async_remove()
 
-    # Get scan interval from options or data, with default fallback
-    scan_interval = entry.options.get(
-        CONF_SCAN_INTERVAL,
-        entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-    )
-
     # Get individual scan intervals for each data type
     scan_interval_charge_points = entry.options.get(
         CONF_SCAN_INTERVAL_CHARGE_POINTS,
@@ -63,21 +59,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
     )
 
-    hass.data[DOMAIN][entry.entry_id] = coordinator = MontaDataUpdateCoordinator(
-        hass=hass,
-        client=MontaApiClient(
-            client_id=entry.data[CONF_CLIENT_ID],
-            client_secret=entry.data[CONF_CLIENT_SECRET],
-            session=async_get_clientsession(hass),
-            store=store,
-        ),
-        scan_interval=scan_interval,
-        scan_interval_charge_points=scan_interval_charge_points,
-        scan_interval_wallet=scan_interval_wallet,
-        scan_interval_transactions=scan_interval_transactions,
+    # Create API client shared by all coordinators
+    client = MontaApiClient(
+        client_id=entry.data[CONF_CLIENT_ID],
+        client_secret=entry.data[CONF_CLIENT_SECRET],
+        session=async_get_clientsession(hass),
+        store=store,
     )
+
+    # Create separate coordinators for each data type
+    charge_point_coordinator = MontaChargePointCoordinator(
+        hass=hass,
+        client=client,
+        scan_interval=scan_interval_charge_points,
+    )
+    wallet_coordinator = MontaWalletCoordinator(
+        hass=hass,
+        client=client,
+        scan_interval=scan_interval_wallet,
+    )
+    transaction_coordinator = MontaTransactionCoordinator(
+        hass=hass,
+        client=client,
+        scan_interval=scan_interval_transactions,
+    )
+
+    # Store coordinators in a dictionary
+    hass.data[DOMAIN][entry.entry_id] = {
+        "charge_point": charge_point_coordinator,
+        "wallet": wallet_coordinator,
+        "transaction": transaction_coordinator,
+    }
+
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
-    await coordinator.async_config_entry_first_refresh()
+    # Refresh all coordinators
+    await charge_point_coordinator.async_config_entry_first_refresh()
+    await wallet_coordinator.async_config_entry_first_refresh()
+    await transaction_coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -12,7 +12,19 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import MontaApiClient
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, STORAGE_KEY, STORAGE_VERSION
+from .const import (
+    CONF_SCAN_INTERVAL,
+    CONF_SCAN_INTERVAL_CHARGE_POINTS,
+    CONF_SCAN_INTERVAL_WALLET,
+    CONF_SCAN_INTERVAL_TRANSACTIONS,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
+    DEFAULT_SCAN_INTERVAL_WALLET,
+    DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
+    DOMAIN,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
 from .coordinator import MontaDataUpdateCoordinator
 from .services import async_setup_services
 
@@ -37,6 +49,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
     )
 
+    # Get individual scan intervals for each data type
+    scan_interval_charge_points = entry.options.get(
+        CONF_SCAN_INTERVAL_CHARGE_POINTS,
+        entry.data.get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
+    )
+    scan_interval_wallet = entry.options.get(
+        CONF_SCAN_INTERVAL_WALLET,
+        entry.data.get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
+    )
+    scan_interval_transactions = entry.options.get(
+        CONF_SCAN_INTERVAL_TRANSACTIONS,
+        entry.data.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
+    )
+
     hass.data[DOMAIN][entry.entry_id] = coordinator = MontaDataUpdateCoordinator(
         hass=hass,
         client=MontaApiClient(
@@ -46,6 +72,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             store=store,
         ),
         scan_interval=scan_interval,
+        scan_interval_charge_points=scan_interval_charge_points,
+        scan_interval_wallet=scan_interval_wallet,
+        scan_interval_transactions=scan_interval_transactions,
     )
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/monta/binary_sensor.py
+++ b/custom_components/monta/binary_sensor.py
@@ -12,8 +12,8 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.helpers.entity import generate_entity_id
 
-from .const import ATTR_CHARGE_POINTS, DOMAIN
-from .coordinator import MontaDataUpdateCoordinator
+from .const import DOMAIN
+from .coordinator import MontaChargePointCoordinator
 from .entity import MontaEntity
 from .utils import snake_case
 
@@ -30,13 +30,14 @@ ENTITY_DESCRIPTIONS = (
 
 async def async_setup_entry(hass, entry, async_add_devices):
     """Set up the binary_sensor platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+    charge_point_coordinator = coordinators["charge_point"]
 
-    for charge_point_id in coordinator.data[ATTR_CHARGE_POINTS]:
+    for charge_point_id in charge_point_coordinator.data:
         async_add_devices(
             [
                 MontaBinarySensor(
-                    coordinator=coordinator,
+                    coordinator=charge_point_coordinator,
                     entity_description=entity_description,
                     charge_point_id=charge_point_id,
                 )
@@ -50,7 +51,7 @@ class MontaBinarySensor(MontaEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        coordinator: MontaDataUpdateCoordinator,
+        coordinator: MontaChargePointCoordinator,
         entity_description: BinarySensorEntityDescription,
         charge_point_id: int,
     ) -> None:
@@ -67,6 +68,6 @@ class MontaBinarySensor(MontaEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary_sensor is on."""
-        return self.coordinator.data[ATTR_CHARGE_POINTS][self.charge_point_id].get(
+        return self.coordinator.data[self.charge_point_id].get(
             self.entity_description.key, False
         )

--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -14,7 +14,20 @@ from .api import (
     MontaApiClientCommunicationError,
     MontaApiClientError,
 )
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, STORAGE_KEY, STORAGE_VERSION
+from .const import (
+    CONF_SCAN_INTERVAL,
+    CONF_SCAN_INTERVAL_CHARGE_POINTS,
+    CONF_SCAN_INTERVAL_WALLET,
+    CONF_SCAN_INTERVAL_TRANSACTIONS,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
+    DEFAULT_SCAN_INTERVAL_WALLET,
+    DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
+    DOMAIN,
+    LOGGER,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
 
 
 class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -73,6 +86,39 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         selector.NumberSelectorConfig(
                             min=30,
                             max=3600,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL_CHARGE_POINTS,
+                        default=(user_input or {}).get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=3600,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL_WALLET,
+                        default=(user_input or {}).get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=7200,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL_TRANSACTIONS,
+                        default=(user_input or {}).get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=7200,
                             unit_of_measurement="seconds",
                             mode=selector.NumberSelectorMode.BOX,
                         ),
@@ -145,6 +191,9 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_CLIENT_ID: user_input[CONF_CLIENT_ID],
                             CONF_CLIENT_SECRET: user_input[CONF_CLIENT_SECRET],
                             CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                            CONF_SCAN_INTERVAL_CHARGE_POINTS: user_input.get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
+                            CONF_SCAN_INTERVAL_WALLET: user_input.get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
+                            CONF_SCAN_INTERVAL_TRANSACTIONS: user_input.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
                         },
                     )
                 return self.async_create_entry(title="", data=user_input)
@@ -185,6 +234,48 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                         selector.NumberSelectorConfig(
                             min=30,
                             max=3600,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL_CHARGE_POINTS,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL_CHARGE_POINTS,
+                            self.config_entry.data.get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=3600,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL_WALLET,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL_WALLET,
+                            self.config_entry.data.get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=7200,
+                            unit_of_measurement="seconds",
+                            mode=selector.NumberSelectorMode.BOX,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL_TRANSACTIONS,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL_TRANSACTIONS,
+                            self.config_entry.data.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
+                        ),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=30,
+                            max=7200,
                             unit_of_measurement="seconds",
                             mode=selector.NumberSelectorMode.BOX,
                         ),

--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -30,6 +30,74 @@ from .const import (
 )
 
 
+def build_schema(defaults: dict) -> vol.Schema:
+    """Build the configuration schema with provided defaults."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_CLIENT_ID,
+                default=defaults.get(CONF_CLIENT_ID),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(
+                    type=selector.TextSelectorType.TEXT
+                ),
+            ),
+            vol.Required(
+                CONF_CLIENT_SECRET,
+                default=defaults.get(CONF_CLIENT_SECRET),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(
+                    type=selector.TextSelectorType.PASSWORD
+                ),
+            ),
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=defaults.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=30,
+                    max=3600,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
+                ),
+            ),
+            vol.Optional(
+                CONF_SCAN_INTERVAL_CHARGE_POINTS,
+                default=defaults.get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=30,
+                    max=3600,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
+                ),
+            ),
+            vol.Optional(
+                CONF_SCAN_INTERVAL_WALLET,
+                default=defaults.get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=30,
+                    max=7200,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
+                ),
+            ),
+            vol.Optional(
+                CONF_SCAN_INTERVAL_TRANSACTIONS,
+                default=defaults.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=30,
+                    max=7200,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
+                ),
+            ),
+        }
+    )
+
+
 class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Monta."""
 
@@ -64,67 +132,7 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_CLIENT_ID,
-                        default=(user_input or {}).get(CONF_CLIENT_ID),
-                    ): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.TEXT
-                        ),
-                    ),
-                    vol.Required(CONF_CLIENT_SECRET): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.PASSWORD
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL,
-                        default=(user_input or {}).get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=3600,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL_CHARGE_POINTS,
-                        default=(user_input or {}).get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=3600,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL_WALLET,
-                        default=(user_input or {}).get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=7200,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL_TRANSACTIONS,
-                        default=(user_input or {}).get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=7200,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                }
-            ),
+            data_schema=build_schema(user_input or {}),
             errors=_errors,
         )
 
@@ -198,90 +206,37 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                     )
                 return self.async_create_entry(title="", data=user_input)
 
+        # Build defaults from user_input -> options -> data
+        defaults = {
+            CONF_CLIENT_ID: (user_input or {}).get(
+                CONF_CLIENT_ID,
+                self.config_entry.data.get(CONF_CLIENT_ID),
+            ),
+            CONF_CLIENT_SECRET: (user_input or {}).get(
+                CONF_CLIENT_SECRET,
+                self.config_entry.data.get(CONF_CLIENT_SECRET),
+            ),
+            CONF_SCAN_INTERVAL: self.config_entry.options.get(
+                CONF_SCAN_INTERVAL,
+                self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            ),
+            CONF_SCAN_INTERVAL_CHARGE_POINTS: self.config_entry.options.get(
+                CONF_SCAN_INTERVAL_CHARGE_POINTS,
+                self.config_entry.data.get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
+            ),
+            CONF_SCAN_INTERVAL_WALLET: self.config_entry.options.get(
+                CONF_SCAN_INTERVAL_WALLET,
+                self.config_entry.data.get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
+            ),
+            CONF_SCAN_INTERVAL_TRANSACTIONS: self.config_entry.options.get(
+                CONF_SCAN_INTERVAL_TRANSACTIONS,
+                self.config_entry.data.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
+            ),
+        }
+
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_CLIENT_ID,
-                        default=(user_input or {}).get(
-                            CONF_CLIENT_ID,
-                            self.config_entry.data.get(CONF_CLIENT_ID),
-                        ),
-                    ): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.TEXT
-                        ),
-                    ),
-                    vol.Required(
-                        CONF_CLIENT_SECRET,
-                        default=(user_input or {}).get(
-                            CONF_CLIENT_SECRET,
-                            self.config_entry.data.get(CONF_CLIENT_SECRET),
-                        ),
-                    ): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.PASSWORD
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL,
-                        default=self.config_entry.options.get(
-                            CONF_SCAN_INTERVAL,
-                            self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-                        ),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=3600,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL_CHARGE_POINTS,
-                        default=self.config_entry.options.get(
-                            CONF_SCAN_INTERVAL_CHARGE_POINTS,
-                            self.config_entry.data.get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
-                        ),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=3600,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL_WALLET,
-                        default=self.config_entry.options.get(
-                            CONF_SCAN_INTERVAL_WALLET,
-                            self.config_entry.data.get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
-                        ),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=7200,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL_TRANSACTIONS,
-                        default=self.config_entry.options.get(
-                            CONF_SCAN_INTERVAL_TRANSACTIONS,
-                            self.config_entry.data.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
-                        ),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=30,
-                            max=7200,
-                            unit_of_measurement="seconds",
-                            mode=selector.NumberSelectorMode.BOX,
-                        ),
-                    ),
-                }
-            ),
+            data_schema=build_schema(defaults),
             errors=_errors,
         )
 

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -17,6 +17,15 @@ ATTR_TRANSACTIONS = "transactions"
 CONF_SCAN_INTERVAL = "scan_interval"
 DEFAULT_SCAN_INTERVAL = 120  # Default to 120 seconds to stay within rate limits
 
+# Separate scan intervals for different data types
+CONF_SCAN_INTERVAL_CHARGE_POINTS = "scan_interval_charge_points"
+CONF_SCAN_INTERVAL_WALLET = "scan_interval_wallet"
+CONF_SCAN_INTERVAL_TRANSACTIONS = "scan_interval_transactions"
+
+DEFAULT_SCAN_INTERVAL_CHARGE_POINTS = 120  # Charge points need frequent updates
+DEFAULT_SCAN_INTERVAL_WALLET = 600  # Wallet updates less frequently (10 minutes)
+DEFAULT_SCAN_INTERVAL_TRANSACTIONS = 600  # Transactions update less frequently (10 minutes)
+
 PREEMPTIVE_REFRESH_TTL_IN_SECONDS = 300
 STORAGE_KEY = "monta_auth"
 STORAGE_VERSION = 1

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+import homeassistant.util.dt as dt_util
 
 from .api import MontaApiClient, MontaApiClientAuthenticationError, MontaApiClientError
 from .const import ATTR_CHARGE_POINTS, ATTR_TRANSACTIONS, ATTR_WALLET, DOMAIN, LOGGER
@@ -19,34 +20,87 @@ class MontaDataUpdateCoordinator(DataUpdateCoordinator):
     config_entry: ConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, client: MontaApiClient, scan_interval: int
+        self,
+        hass: HomeAssistant,
+        client: MontaApiClient,
+        scan_interval: int,
+        scan_interval_charge_points: int,
+        scan_interval_wallet: int,
+        scan_interval_transactions: int,
     ) -> None:
         """Initialize."""
         self.client = client
+
+        # Store individual scan intervals for each data type
+        self.scan_interval_charge_points = scan_interval_charge_points
+        self.scan_interval_wallet = scan_interval_wallet
+        self.scan_interval_transactions = scan_interval_transactions
+
+        # Track last update time for each data type
+        self._last_update_charge_points: datetime | None = None
+        self._last_update_wallet: datetime | None = None
+        self._last_update_transactions: datetime | None = None
+
+        # Use the smallest interval as the coordinator's update interval
+        # so it runs frequently enough to check all data types
+        min_interval = min(
+            scan_interval_charge_points,
+            scan_interval_wallet,
+            scan_interval_transactions,
+        )
+
         super().__init__(
             hass=hass,
             logger=LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=scan_interval),
+            update_interval=timedelta(seconds=min_interval),
         )
+
+    def _should_update(self, last_update: datetime | None, interval: int) -> bool:
+        """Check if data should be updated based on interval."""
+        if last_update is None:
+            return True
+        now = dt_util.utcnow()
+        return (now - last_update).total_seconds() >= interval
 
     async def _async_update_data(self):
         """Update data via library."""
         try:
-            charge_points = await self.client.async_get_charge_points()
-            for charge_point_id in charge_points:
-                charge_points[charge_point_id][
-                    "charges"
-                ] = await self.client.async_get_charges(charge_point_id)
+            now = dt_util.utcnow()
+            result = {}
 
-            personal_wallet = await self.client.async_get_personal_wallet()
-            wallet_transactions = await self.client.async_get_wallet_transactions()
+            # Only fetch data if the interval has passed since last update
+            # Start with existing data if available
+            if self.data:
+                result = self.data.copy()
 
-            return {
-                ATTR_CHARGE_POINTS: charge_points,
-                ATTR_WALLET: personal_wallet,
-                ATTR_TRANSACTIONS: wallet_transactions,
-            }
+            # Update charge points if interval has passed
+            if self._should_update(
+                self._last_update_charge_points, self.scan_interval_charge_points
+            ):
+                charge_points = await self.client.async_get_charge_points()
+                for charge_point_id in charge_points:
+                    charge_points[charge_point_id][
+                        "charges"
+                    ] = await self.client.async_get_charges(charge_point_id)
+                result[ATTR_CHARGE_POINTS] = charge_points
+                self._last_update_charge_points = now
+
+            # Update wallet if interval has passed
+            if self._should_update(
+                self._last_update_wallet, self.scan_interval_wallet
+            ):
+                result[ATTR_WALLET] = await self.client.async_get_personal_wallet()
+                self._last_update_wallet = now
+
+            # Update transactions if interval has passed
+            if self._should_update(
+                self._last_update_transactions, self.scan_interval_transactions
+            ):
+                result[ATTR_TRANSACTIONS] = await self.client.async_get_wallet_transactions()
+                self._last_update_transactions = now
+
+            return result
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except MontaApiClientError as exception:

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -2,20 +2,19 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-import homeassistant.util.dt as dt_util
 
 from .api import MontaApiClient, MontaApiClientAuthenticationError, MontaApiClientError
-from .const import ATTR_CHARGE_POINTS, ATTR_TRANSACTIONS, ATTR_WALLET, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 
 
-class MontaDataUpdateCoordinator(DataUpdateCoordinator):
-    """Class to manage fetching data from the API."""
+class MontaChargePointCoordinator(DataUpdateCoordinator):
+    """Coordinator for charge point data."""
 
     config_entry: ConfigEntry
 
@@ -24,83 +23,25 @@ class MontaDataUpdateCoordinator(DataUpdateCoordinator):
         hass: HomeAssistant,
         client: MontaApiClient,
         scan_interval: int,
-        scan_interval_charge_points: int,
-        scan_interval_wallet: int,
-        scan_interval_transactions: int,
     ) -> None:
         """Initialize."""
         self.client = client
-
-        # Store individual scan intervals for each data type
-        self.scan_interval_charge_points = scan_interval_charge_points
-        self.scan_interval_wallet = scan_interval_wallet
-        self.scan_interval_transactions = scan_interval_transactions
-
-        # Track last update time for each data type
-        self._last_update_charge_points: datetime | None = None
-        self._last_update_wallet: datetime | None = None
-        self._last_update_transactions: datetime | None = None
-
-        # Use the smallest interval as the coordinator's update interval
-        # so it runs frequently enough to check all data types
-        min_interval = min(
-            scan_interval_charge_points,
-            scan_interval_wallet,
-            scan_interval_transactions,
-        )
-
         super().__init__(
             hass=hass,
             logger=LOGGER,
-            name=DOMAIN,
-            update_interval=timedelta(seconds=min_interval),
+            name=f"{DOMAIN}_charge_points",
+            update_interval=timedelta(seconds=scan_interval),
         )
 
-    def _should_update(self, last_update: datetime | None, interval: int) -> bool:
-        """Check if data should be updated based on interval."""
-        if last_update is None:
-            return True
-        now = dt_util.utcnow()
-        return (now - last_update).total_seconds() >= interval
-
     async def _async_update_data(self):
-        """Update data via library."""
+        """Update charge point data via library."""
         try:
-            now = dt_util.utcnow()
-            result = {}
-
-            # Only fetch data if the interval has passed since last update
-            # Start with existing data if available
-            if self.data:
-                result = self.data.copy()
-
-            # Update charge points if interval has passed
-            if self._should_update(
-                self._last_update_charge_points, self.scan_interval_charge_points
-            ):
-                charge_points = await self.client.async_get_charge_points()
-                for charge_point_id in charge_points:
-                    charge_points[charge_point_id][
-                        "charges"
-                    ] = await self.client.async_get_charges(charge_point_id)
-                result[ATTR_CHARGE_POINTS] = charge_points
-                self._last_update_charge_points = now
-
-            # Update wallet if interval has passed
-            if self._should_update(
-                self._last_update_wallet, self.scan_interval_wallet
-            ):
-                result[ATTR_WALLET] = await self.client.async_get_personal_wallet()
-                self._last_update_wallet = now
-
-            # Update transactions if interval has passed
-            if self._should_update(
-                self._last_update_transactions, self.scan_interval_transactions
-            ):
-                result[ATTR_TRANSACTIONS] = await self.client.async_get_wallet_transactions()
-                self._last_update_transactions = now
-
-            return result
+            charge_points = await self.client.async_get_charge_points()
+            for charge_point_id in charge_points:
+                charge_points[charge_point_id][
+                    "charges"
+                ] = await self.client.async_get_charges(charge_point_id)
+            return charge_points
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except MontaApiClientError as exception:
@@ -117,11 +58,69 @@ class MontaDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_stop_charge(self, charge_point_id: int):
         """Stop a charge."""
-
         charges = await self.client.async_get_charges(charge_point_id)
-
         try:
             return await self.client.async_stop_charge(charges[0]["id"])
+        except MontaApiClientAuthenticationError as exception:
+            raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientError as exception:
+            raise UpdateFailed(exception) from exception
+
+
+class MontaWalletCoordinator(DataUpdateCoordinator):
+    """Coordinator for wallet data."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: MontaApiClient,
+        scan_interval: int,
+    ) -> None:
+        """Initialize."""
+        self.client = client
+        super().__init__(
+            hass=hass,
+            logger=LOGGER,
+            name=f"{DOMAIN}_wallet",
+            update_interval=timedelta(seconds=scan_interval),
+        )
+
+    async def _async_update_data(self):
+        """Update wallet data via library."""
+        try:
+            return await self.client.async_get_personal_wallet()
+        except MontaApiClientAuthenticationError as exception:
+            raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientError as exception:
+            raise UpdateFailed(exception) from exception
+
+
+class MontaTransactionCoordinator(DataUpdateCoordinator):
+    """Coordinator for transaction data."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: MontaApiClient,
+        scan_interval: int,
+    ) -> None:
+        """Initialize."""
+        self.client = client
+        super().__init__(
+            hass=hass,
+            logger=LOGGER,
+            name=f"{DOMAIN}_transactions",
+            update_interval=timedelta(seconds=scan_interval),
+        )
+
+    async def _async_update_data(self):
+        """Update transaction data via library."""
+        try:
+            return await self.client.async_get_wallet_transactions()
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
         except MontaApiClientError as exception:

--- a/custom_components/monta/entity.py
+++ b/custom_components/monta/entity.py
@@ -5,18 +5,18 @@ from __future__ import annotations
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_CHARGE_POINTS, ATTRIBUTION, DOMAIN
-from .coordinator import MontaDataUpdateCoordinator
+from .const import ATTRIBUTION, DOMAIN
+from .coordinator import MontaChargePointCoordinator
 
 
-class MontaEntity(CoordinatorEntity[MontaDataUpdateCoordinator]):
+class MontaEntity(CoordinatorEntity[MontaChargePointCoordinator]):
     """MontaEntity class."""
 
     _attr_attribution = ATTRIBUTION
     _attr_has_entity_name = True
 
     def __init__(
-        self, coordinator: MontaDataUpdateCoordinator, charge_point_id: int
+        self, coordinator: MontaChargePointCoordinator, charge_point_id: int
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -25,7 +25,7 @@ class MontaEntity(CoordinatorEntity[MontaDataUpdateCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this Wallbox device."""
-        chargepoint = self.coordinator.data[ATTR_CHARGE_POINTS][self.charge_point_id]
+        chargepoint = self.coordinator.data[self.charge_point_id]
         return DeviceInfo(
             identifiers={
                 (

--- a/custom_components/monta/services.py
+++ b/custom_components/monta/services.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 
-from .const import ATTR_CHARGE_POINTS, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,16 +21,17 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
     _LOGGER.debug("Set up services")
 
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+    charge_point_coordinator = coordinators["charge_point"]
 
     async def service_handle_stop_charging(service_call: ServiceCall) -> None:
         charge_point_id = service_call.data["charge_point_id"]
         _LOGGER.debug("Called stop charging for %s", charge_point_id)
 
-        if coordinator.data[ATTR_CHARGE_POINTS][charge_point_id]["state"].startswith(
+        if charge_point_coordinator.data[charge_point_id]["state"].startswith(
             "busy"
         ):
-            await coordinator.async_stop_charge(charge_point_id)
+            await charge_point_coordinator.async_stop_charge(charge_point_id)
             return
 
         raise vol.Invalid("Charger not currently charging")
@@ -39,8 +40,8 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         charge_point_id = service_call.data["charge_point_id"]
         _LOGGER.debug("Called start charging for %s", charge_point_id)
 
-        if coordinator.data[ATTR_CHARGE_POINTS][charge_point_id]["state"] == "available":
-            await coordinator.async_start_charge(charge_point_id)
+        if charge_point_coordinator.data[charge_point_id]["state"] == "available":
+            await charge_point_coordinator.async_start_charge(charge_point_id)
             return
 
         raise vol.Invalid("Charger not currently charging")


### PR DESCRIPTION
# Add variable scan intervals for different API endpoints

## Summary

This PR adds support for configurable scan intervals for different API endpoints, allowing users to reduce API calls for data that doesn't need frequent updates. The implementation uses multiple independent coordinators following Home Assistant best practices.

## Changes

### 1. Variable Scan Intervals Configuration

Added three separate configurable scan intervals:
- **Charge Points**: 120 seconds (default) - Real-time charging status
- **Wallet**: 600 seconds (default) - Balance updates less frequently  
- **Transactions**: 600 seconds (default) - Historical data updates less frequently

Users can configure each interval independently through the integration settings UI (30-7200 seconds range).

### 2. Multiple Coordinator Architecture

Refactored from a single coordinator to three independent coordinators:
- `MontaChargePointCoordinator` - Manages charge point data
- `MontaWalletCoordinator` - Manages wallet data
- `MontaTransactionCoordinator` - Manages transaction data

**Benefits:**
- ✅ More efficient - coordinators only run when their data needs updating
- ✅ Better rate limiting - API calls spread out naturally instead of bursting
- ✅ Direct data access - `coordinator.data` instead of `coordinator.data[ATTR_*]`

### 3. Shared Configuration Schema

Extracted duplicated schema code into a shared `build_schema()` function used by both setup and options flows.

**Benefits:**
- ✅ Single source of truth for configuration fields
- ✅ Easier to maintain and modify

## Technical Details

### Data Flow
- Time 0s: All 3 coordinators fetch data (first run) 
- Time 120s: Charge point coordinator updates 
- Time 240s: Charge point coordinator updates
- Time 360s: Charge point coordinator updates 
- Time 480s: Charge point coordinator updates 
- Time 600s: All 3 coordinators update

Each coordinator independently manages its own update schedule.

### Configuration Storage

All scan interval settings are stored in the config entry data and can be modified through the integration options flow. Backward compatibility is maintained - existing installations will use default values.
