### PR TITLE
Remove unused generic scan_interval configuration

### DIFF
--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -15,11 +15,9 @@ from .api import (
     MontaApiClientError,
 )
 from .const import (
-    CONF_SCAN_INTERVAL,
     CONF_SCAN_INTERVAL_CHARGE_POINTS,
     CONF_SCAN_INTERVAL_WALLET,
     CONF_SCAN_INTERVAL_TRANSACTIONS,
-    DEFAULT_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
     DEFAULT_SCAN_INTERVAL_WALLET,
     DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
@@ -48,17 +46,6 @@ def build_schema(defaults: dict) -> vol.Schema:
             ): selector.TextSelector(
                 selector.TextSelectorConfig(
                     type=selector.TextSelectorType.PASSWORD
-                ),
-            ),
-            vol.Optional(
-                CONF_SCAN_INTERVAL,
-                default=defaults.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=30,
-                    max=3600,
-                    unit_of_measurement="seconds",
-                    mode=selector.NumberSelectorMode.BOX,
                 ),
             ),
             vol.Optional(
@@ -198,7 +185,6 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                         data={
                             CONF_CLIENT_ID: user_input[CONF_CLIENT_ID],
                             CONF_CLIENT_SECRET: user_input[CONF_CLIENT_SECRET],
-                            CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
                             CONF_SCAN_INTERVAL_CHARGE_POINTS: user_input.get(CONF_SCAN_INTERVAL_CHARGE_POINTS, DEFAULT_SCAN_INTERVAL_CHARGE_POINTS),
                             CONF_SCAN_INTERVAL_WALLET: user_input.get(CONF_SCAN_INTERVAL_WALLET, DEFAULT_SCAN_INTERVAL_WALLET),
                             CONF_SCAN_INTERVAL_TRANSACTIONS: user_input.get(CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS),
@@ -215,10 +201,6 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_CLIENT_SECRET: (user_input or {}).get(
                 CONF_CLIENT_SECRET,
                 self.config_entry.data.get(CONF_CLIENT_SECRET),
-            ),
-            CONF_SCAN_INTERVAL: self.config_entry.options.get(
-                CONF_SCAN_INTERVAL,
-                self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
             ),
             CONF_SCAN_INTERVAL_CHARGE_POINTS: self.config_entry.options.get(
                 CONF_SCAN_INTERVAL_CHARGE_POINTS,

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -14,9 +14,6 @@ ATTR_CHARGE_POINTS = "charge_points"
 ATTR_WALLET = "wallet"
 ATTR_TRANSACTIONS = "transactions"
 
-CONF_SCAN_INTERVAL = "scan_interval"
-DEFAULT_SCAN_INTERVAL = 120  # Default to 120 seconds to stay within rate limits
-
 # Separate scan intervals for different data types
 CONF_SCAN_INTERVAL_CHARGE_POINTS = "scan_interval_charge_points"
 CONF_SCAN_INTERVAL_WALLET = "scan_interval_wallet"

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -6,10 +6,14 @@
 				"data": {
 					"client_id": "Client id",
 					"client_secret": "client secret",
-					"scan_interval": "Scan interval (seconds)"
+					"scan_interval_charge_points": "Charge Points Scan Interval (seconds)",
+					"scan_interval_wallet": "Wallet Scan Interval (seconds)",
+					"scan_interval_transactions": "Transactions Scan Interval (seconds)"
 				},
 				"data_description": {
-					"scan_interval": "How often to fetch data from Monta API. Monta has a rate limit of 10 requests per minute. Recommended: 120 seconds or higher for multiple chargers."
+					"scan_interval_charge_points": "How often to fetch charge point data. Recommended: 120 seconds (Monta has rate limit of 10 requests/min)",
+					"scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
+					"scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
 				}
 			}
 		},
@@ -22,16 +26,20 @@
 	"options": {
 		"step": {
 			"init": {
-				"description": "Configure Monta integration options. You can update your credentials or adjust the scan interval here.",
+				"description": "Configure Monta integration options. You can update your credentials or adjust the scan intervals here.",
 				"data": {
 					"client_id": "Client id",
 					"client_secret": "Client secret",
-					"scan_interval": "Scan interval (seconds)"
+					"scan_interval_charge_points": "Charge Points Scan Interval (seconds)",
+					"scan_interval_wallet": "Wallet Scan Interval (seconds)",
+					"scan_interval_transactions": "Transactions Scan Interval (seconds)"
 				},
 				"data_description": {
 					"client_id": "Your Monta API client ID from https://portal2.monta.app/applications",
 					"client_secret": "Your Monta API client secret from https://portal2.monta.app/applications",
-					"scan_interval": "How often to fetch data from Monta API. Monta has a rate limit of 10 requests per minute. Recommended: 120 seconds or higher for multiple chargers."
+					"scan_interval_charge_points": "How often to fetch charge point data. Recommended: 120 seconds (Monta has rate limit of 10 requests/min)",
+					"scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
+					"scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
 				}
 			}
 		}

--- a/custom_components/monta/translations/pt.json
+++ b/custom_components/monta/translations/pt.json
@@ -6,10 +6,14 @@
         "data": {
           "client_id": "ID do cliente",
           "client_secret": "Segredo do cliente",
-          "scan_interval": "Intervalo de varredura (segundos)"
+          "scan_interval_charge_points": "Intervalo de Pontos de Carregamento (segundos)",
+          "scan_interval_wallet": "Intervalo de Carteira (segundos)",
+          "scan_interval_transactions": "Intervalo de Transações (segundos)"
         },
         "data_description": {
-          "scan_interval": "Com que frequência buscar dados da API Monta. A Monta tem um limite de 10 solicitações por minuto. Recomendado: 120 segundos ou mais para vários carregadores."
+          "scan_interval_charge_points": "Com que frequência buscar dados dos pontos de carregamento. Recomendado: 120 segundos (Monta tem limite de 10 solicitações/min)",
+          "scan_interval_wallet": "Com que frequência buscar dados da carteira. Recomendado: 600 segundos (10 minutos)",
+          "scan_interval_transactions": "Com que frequência buscar dados de transações. Recomendado: 600 segundos (10 minutos)"
         }
       }
     },
@@ -22,16 +26,20 @@
   "options": {
     "step": {
       "init": {
-        "description": "Configurar opções de integração Monta. Você pode atualizar suas credenciais ou ajustar o intervalo de varredura aqui.",
+        "description": "Configurar opções de integração Monta. Você pode atualizar suas credenciais ou ajustar os intervalos de varredura aqui.",
         "data": {
           "client_id": "ID do cliente",
           "client_secret": "Segredo do cliente",
-          "scan_interval": "Intervalo de varredura (segundos)"
+          "scan_interval_charge_points": "Intervalo de Pontos de Carregamento (segundos)",
+          "scan_interval_wallet": "Intervalo de Carteira (segundos)",
+          "scan_interval_transactions": "Intervalo de Transações (segundos)"
         },
         "data_description": {
           "client_id": "Seu ID de cliente da API Monta de https://portal2.monta.app/applications",
           "client_secret": "Seu segredo de cliente da API Monta de https://portal2.monta.app/applications",
-          "scan_interval": "Com que frequência buscar dados da API Monta. A Monta tem um limite de 10 solicitações por minuto. Recomendado: 120 segundos ou mais para vários carregadores."
+          "scan_interval_charge_points": "Com que frequência buscar dados dos pontos de carregamento. Recomendado: 120 segundos (Monta tem limite de 10 solicitações/min)",
+          "scan_interval_wallet": "Com que frequência buscar dados da carteira. Recomendado: 600 segundos (10 minutos)",
+          "scan_interval_transactions": "Com que frequência buscar dados de transações. Recomendado: 600 segundos (10 minutos)"
         }
       }
     }


### PR DESCRIPTION
The generic CONF_SCAN_INTERVAL wis no longer used. The code now only uses the three specific scan intervals:
- scan_interval_charge_points
- scan_interval_wallet
- scan_interval_transactions

This removes the unused configuration constant and updates the UI and translations to only show the three specific scan intervals that are actually used by the coordinators.

Fixes duplicate scan interval configuration issue.