### PR TITLE
Throttle per-charge-point detail requests to avoid 429 rate limiting

### DIFF
--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -14,13 +14,16 @@ from homeassistant.helpers.storage import Store
 from monta import MontaApiClient
 
 from .const import (
+    CONF_CHARGE_POINT_REQUEST_DELAY,
     CONF_SCAN_INTERVAL_CHARGE_POINTS,
     CONF_SCAN_INTERVAL_TRANSACTIONS,
     CONF_SCAN_INTERVAL_WALLET,
+    DEFAULT_CHARGE_POINT_REQUEST_DELAY,
     DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
     DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
     DEFAULT_SCAN_INTERVAL_WALLET,
     DOMAIN,
+    LOGGER,
     STORAGE_KEY,
     STORAGE_VERSION,
 )
@@ -68,6 +71,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_SCAN_INTERVAL_TRANSACTIONS, DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
         ),
     )
+    charge_point_request_delay = entry.options.get(
+        CONF_CHARGE_POINT_REQUEST_DELAY,
+        entry.data.get(
+            CONF_CHARGE_POINT_REQUEST_DELAY, DEFAULT_CHARGE_POINT_REQUEST_DELAY,
+        ),
+    )
 
     # Create API client shared by all coordinators
     client = MontaApiClient(
@@ -82,6 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass=hass,
         client=client,
         scan_interval=scan_interval_charge_points,
+        request_delay=charge_point_request_delay,
     )
     wallet_coordinator = MontaWalletCoordinator(
         hass=hass,
@@ -106,6 +116,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await charge_point_coordinator.async_config_entry_first_refresh()
     await wallet_coordinator.async_config_entry_first_refresh()
     await transaction_coordinator.async_config_entry_first_refresh()
+
+    # Warn if the throttled charge-point cycle can't finish within its interval.
+    charge_point_count = len(charge_point_coordinator.data or {})
+    estimated_cycle = charge_point_request_delay * max(charge_point_count - 1, 0)
+    if estimated_cycle >= scan_interval_charge_points:
+        LOGGER.warning(
+            "Monta charge-point update may not finish in time: %d chargers x %ss "
+            "delay = ~%ds, which is >= the %ds scan interval. Increase the charge "
+            "points scan interval or lower the request delay in the integration "
+            "options.",
+            charge_point_count,
+            charge_point_request_delay,
+            estimated_cycle,
+            scan_interval_charge_points,
+        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -18,9 +18,11 @@ from monta import (
 )
 
 from .const import (
+    CONF_CHARGE_POINT_REQUEST_DELAY,
     CONF_SCAN_INTERVAL_CHARGE_POINTS,
     CONF_SCAN_INTERVAL_TRANSACTIONS,
     CONF_SCAN_INTERVAL_WALLET,
+    DEFAULT_CHARGE_POINT_REQUEST_DELAY,
     DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
     DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
     DEFAULT_SCAN_INTERVAL_WALLET,
@@ -89,6 +91,20 @@ def build_schema(defaults: dict) -> vol.Schema:
                 selector.NumberSelectorConfig(
                     min=30,
                     max=7200,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
+                ),
+            ),
+            vol.Optional(
+                CONF_CHARGE_POINT_REQUEST_DELAY,
+                default=defaults.get(
+                    CONF_CHARGE_POINT_REQUEST_DELAY,
+                    DEFAULT_CHARGE_POINT_REQUEST_DELAY,
+                ),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0,
+                    max=60,
                     unit_of_measurement="seconds",
                     mode=selector.NumberSelectorMode.BOX,
                 ),
@@ -212,6 +228,10 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                                 CONF_SCAN_INTERVAL_TRANSACTIONS,
                                 DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
                             ),
+                            CONF_CHARGE_POINT_REQUEST_DELAY: user_input.get(
+                                CONF_CHARGE_POINT_REQUEST_DELAY,
+                                DEFAULT_CHARGE_POINT_REQUEST_DELAY,
+                            ),
                         },
                     )
                 return self.async_create_entry(title="", data=user_input)
@@ -245,6 +265,13 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                 self.config_entry.data.get(
                     CONF_SCAN_INTERVAL_TRANSACTIONS,
                     DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
+                ),
+            ),
+            CONF_CHARGE_POINT_REQUEST_DELAY: self.config_entry.options.get(
+                CONF_CHARGE_POINT_REQUEST_DELAY,
+                self.config_entry.data.get(
+                    CONF_CHARGE_POINT_REQUEST_DELAY,
+                    DEFAULT_CHARGE_POINT_REQUEST_DELAY,
                 ),
             ),
         }

--- a/custom_components/monta/const.py
+++ b/custom_components/monta/const.py
@@ -19,11 +19,19 @@ CONF_SCAN_INTERVAL_CHARGE_POINTS = "scan_interval_charge_points"
 CONF_SCAN_INTERVAL_WALLET = "scan_interval_wallet"
 CONF_SCAN_INTERVAL_TRANSACTIONS = "scan_interval_transactions"
 
+# Delay between the per-charge-point detail requests in a single update cycle.
+# Monta's public API allows ~10 requests/min. A full charge-point update makes
+# 1 list call + 1 detail call per charge point, so for several chargers the
+# requests must be spread out to stay under the limit and avoid HTTP 429.
+# 8s => ~7.5 req/min, leaving headroom for the wallet/transaction coordinators.
+CONF_CHARGE_POINT_REQUEST_DELAY = "charge_point_request_delay"
+
 DEFAULT_SCAN_INTERVAL_CHARGE_POINTS = 120  # Charge points need frequent updates
 DEFAULT_SCAN_INTERVAL_WALLET = 600  # Wallet updates less frequently (10 minutes)
 DEFAULT_SCAN_INTERVAL_TRANSACTIONS = (
     600  # Transactions update less frequently (10 minutes)
 )
+DEFAULT_CHARGE_POINT_REQUEST_DELAY = 8  # seconds between per-charger detail calls
 
 PREEMPTIVE_REFRESH_TTL_IN_SECONDS = 300
 STORAGE_KEY = "monta_auth"

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -14,7 +15,7 @@ from monta import (
 )
 from monta.models import Charge, ChargePoint, Wallet, WalletTransaction
 
-from .const import DOMAIN, LOGGER
+from .const import DEFAULT_CHARGE_POINT_REQUEST_DELAY, DOMAIN, LOGGER
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -32,9 +33,11 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
         hass: HomeAssistant,
         client: MontaApiClient,
         scan_interval: int,
+        request_delay: float = DEFAULT_CHARGE_POINT_REQUEST_DELAY,
     ) -> None:
         """Initialize."""
         self.client = client
+        self.request_delay = request_delay
         super().__init__(
             hass=hass,
             logger=LOGGER,
@@ -43,10 +46,18 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
         )
 
     async def _async_update_data(self) -> dict[int, ChargePoint]:
-        """Update charge point data via library."""
+        """Update charge point data via library.
+
+        The detail call for each charge point is spaced out by
+        ``request_delay`` seconds so that accounts with many chargers stay
+        within Monta's ~10 requests/minute limit and don't trigger HTTP 429.
+        """
         try:
             charge_points = await self.client.async_get_charge_points()
-            for charge_point_id in charge_points:
+            for index, charge_point_id in enumerate(charge_points):
+                # Throttle between detail calls (not before the first one).
+                if index > 0 and self.request_delay > 0:
+                    await asyncio.sleep(self.request_delay)
                 charge_points[
                     charge_point_id
                 ].charges = await self.client.async_get_charges(charge_point_id)

--- a/custom_components/monta/strings.json
+++ b/custom_components/monta/strings.json
@@ -8,12 +8,14 @@
 					"client_secret": "Client Secret",
 					"scan_interval_charge_points": "Charge Points Scan Interval (seconds)",
 					"scan_interval_wallet": "Wallet Scan Interval (seconds)",
-					"scan_interval_transactions": "Transactions Scan Interval (seconds)"
+					"scan_interval_transactions": "Transactions Scan Interval (seconds)",
+					"charge_point_request_delay": "Delay between chargers (seconds)"
 				},
 				"data_description": {
 					"scan_interval_charge_points": "How often to fetch charge point data. Recommended: 120 seconds (Monta has rate limit of 10 requests/min)",
 					"scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
-					"scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
+					"scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)",
+					"charge_point_request_delay": "Pause between fetching each charger's details, to stay under Monta's ~10 requests/min limit. Default 8s. Keep delay x (chargers - 1) below the charge points scan interval. Set 0 to disable."
 				}
 			}
 		},
@@ -35,14 +37,16 @@
 					"client_secret": "Client Secret",
 					"scan_interval_charge_points": "Charge Points Scan Interval (seconds)",
 					"scan_interval_wallet": "Wallet Scan Interval (seconds)",
-					"scan_interval_transactions": "Transactions Scan Interval (seconds)"
+					"scan_interval_transactions": "Transactions Scan Interval (seconds)",
+					"charge_point_request_delay": "Delay between chargers (seconds)"
 				},
 				"data_description": {
 					"client_id": "Your Monta API Client ID from https://portal2.monta.app/applications",
 					"client_secret": "Your Monta API Client Secret from https://portal2.monta.app/applications",
 					"scan_interval_charge_points": "How often to fetch charge point data. Recommended: 120 seconds (Monta has rate limit of 10 requests/min)",
 					"scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
-					"scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
+					"scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)",
+					"charge_point_request_delay": "Pause between fetching each charger's details, to stay under Monta's ~10 requests/min limit. Default 8s. Keep delay x (chargers - 1) below the charge points scan interval. Set 0 to disable."
 				}
 			}
 		},

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -8,12 +8,14 @@
           "client_secret": "Client Secret",
           "scan_interval_charge_points": "Charge Points Scan Interval (seconds)",
           "scan_interval_wallet": "Wallet Scan Interval (seconds)",
-          "scan_interval_transactions": "Transactions Scan Interval (seconds)"
+          "scan_interval_transactions": "Transactions Scan Interval (seconds)",
+          "charge_point_request_delay": "Delay between chargers (seconds)"
         },
         "data_description": {
           "scan_interval_charge_points": "How often to fetch charge point data. Recommended: 120 seconds (Monta has rate limit of 10 requests/min)",
           "scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
-          "scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
+          "scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)",
+          "charge_point_request_delay": "Pause between fetching each charger's details, to stay under Monta's ~10 requests/min limit. Default 8s. Keep delay x (chargers - 1) below the charge points scan interval. Set 0 to disable."
         }
       }
     },
@@ -35,14 +37,16 @@
           "client_secret": "Client Secret",
           "scan_interval_charge_points": "Charge Points Scan Interval (seconds)",
           "scan_interval_wallet": "Wallet Scan Interval (seconds)",
-          "scan_interval_transactions": "Transactions Scan Interval (seconds)"
+          "scan_interval_transactions": "Transactions Scan Interval (seconds)",
+          "charge_point_request_delay": "Delay between chargers (seconds)"
         },
         "data_description": {
           "client_id": "Your Monta API Client ID from https://portal2.monta.app/applications",
           "client_secret": "Your Monta API Client Secret from https://portal2.monta.app/applications",
           "scan_interval_charge_points": "How often to fetch charge point data. Recommended: 120 seconds (Monta has rate limit of 10 requests/min)",
           "scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
-          "scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
+          "scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)",
+          "charge_point_request_delay": "Pause between fetching each charger's details, to stay under Monta's ~10 requests/min limit. Default 8s. Keep delay x (chargers - 1) below the charge points scan interval. Set 0 to disable."
         }
       }
     },


### PR DESCRIPTION
## Problem

On accounts with several chargers the integration repeatedly fails with rate-limit errors. Each charge-point update cycle issues:

- 1 call to list charge points, then
- 1 `async_get_charges` detail call **per charge point**, back-to-back

With 12 chargers that is ~13 requests fired within a couple of seconds. Monta's public API allows ~10 requests/min (as noted in the integration's own `strings.json`), so the burst returns **HTTP 429**, which Home Assistant surfaces as a generic "rate limited" / update failure.

## Fix

Add a configurable `charge_point_request_delay` option (default **8s**) that sleeps between the per-charge-point detail calls in `MontaChargePointCoordinator._async_update_data`. This spreads a 12-charger cycle to ~7.5 req/min, staying under the limit with headroom for the wallet/transaction coordinators. The delay is applied between calls only (not before the first), so single-charger accounts are unaffected.

- New constant `CONF_CHARGE_POINT_REQUEST_DELAY` / `DEFAULT_CHARGE_POINT_REQUEST_DELAY = 8` in `const.py`
- Coordinator throttles with `asyncio.sleep(self.request_delay)` between detail calls
- Option wired through `__init__.py` (data + options) and exposed in the config/options flow (`NumberSelector`, 0–60s; 0 disables)
- `__init__.py` logs a warning when `delay × (chargers − 1)` would exceed the charge-points scan interval
- Labels/descriptions added to `strings.json` and `translations/en.json`

## Notes / trade-off

With throttling, the first refresh during setup/reload now takes ~`delay × (chargers − 1)` seconds (e.g. ~88s for 12 chargers at 8s). This keeps setup under the rate limit; users with many chargers who want a faster cycle can lower the delay and raise the charge-points scan interval. Default is unchanged for single-charger users (one detail call, no sleep).

## Testing

Patched a live instance with 12 chargers: integration loads cleanly, all entities populate, and no further 429s in the log across multiple poll cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)