### PR TITLE
Fetch charge point data with 2 requests per cycle to avoid 429 rate limiting

### DIFF
--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -13,7 +13,7 @@ from monta import (
     MontaApiClientError,
     MontaApiClientRateLimitError,
 )
-from monta.models import Charge, ChargePoint, Wallet, WalletTransaction
+from monta.models import Charge, ChargePoint, ChargeState, Wallet, WalletTransaction
 
 from .const import DOMAIN, LOGGER
 
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 
 # Latest charges fetched per update cycle, across all charge points.
 CHARGES_PER_UPDATE = 100
+
+# States in which a charge record no longer changes server-side. Any state
+# change after these comes from a new charge, which by having a newer id is
+# guaranteed to appear in the bulk batch.
+CHARGE_TERMINAL_STATES = {ChargeState.STOPPED.value, ChargeState.COMPLETED.value}
 
 
 def _rate_limit_message(exception: MontaApiClientRateLimitError) -> str:
@@ -62,10 +67,14 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
 
         Uses two requests per cycle regardless of charger count: one
         paginated charge-point fetch and one bulk charges fetch, so accounts
-        with many chargers stay under Monta's ~10 requests/minute limit. A
-        charger whose last charge is older than the whole bulk batch gets one
-        targeted fetch, once per charger, so its last-charge sensors still
-        populate.
+        with many chargers stay under Monta's ~10 requests/minute limit.
+
+        Chargers absent from the bulk batch get a targeted fetch when their
+        data can't be derived from it: once ever for chargers never seen
+        with a charge, and every cycle while their latest known charge is
+        still active (its record mutates server-side). A retained terminal
+        charge never goes stale, since any state change comes from a newer
+        charge that is guaranteed to appear in the batch.
         """
         try:
             charge_points = await self.client.async_get_all_charge_points()
@@ -85,25 +94,30 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
                 charge.charge_point_id, [],
             ).append(charge)
 
-        needs_backfill: list[int] = []
+        needs_fetch: list[int] = []
         for charge_point_id, charge_point in charge_points.items():
             if charge_point_id in charges_by_charge_point:
                 charge_point.charges = charges_by_charge_point[charge_point_id]
-            elif previous_charges := self._previous_charges(charge_point_id):
-                # A charger with no charge in the latest batch keeps the
-                # charges from the previous cycle instead of going empty.
+                continue
+            previous_charges = self._previous_charges(charge_point_id)
+            if previous_charges:
+                # Keep the previous cycle's charges instead of going empty;
+                # also serves as the fallback if the fetch below rate-limits.
                 charge_point.charges = previous_charges
+                if previous_charges[0].state not in CHARGE_TERMINAL_STATES:
+                    # Still active: the record mutates, so refetch it.
+                    needs_fetch.append(charge_point_id)
             elif charge_point_id not in self._backfilled_charge_points:
-                needs_backfill.append(charge_point_id)
+                needs_fetch.append(charge_point_id)
 
-        for charge_point_id in needs_backfill:
+        for charge_point_id in needs_fetch:
             try:
-                backfill = await self.client.async_get_charges(charge_point_id)
+                fetched = await self.client.async_get_charges(charge_point_id)
             except MontaApiClientAuthenticationError as exception:
                 raise ConfigEntryAuthFailed(exception) from exception
             except MontaApiClientRateLimitError:
                 # Keep the bulk data already gathered; chargers not yet
-                # backfilled stay pending and are retried next cycle.
+                # fetched stay pending and are retried next cycle.
                 LOGGER.warning(
                     "Rate limited while fetching charges for charge point "
                     "%s; retrying on the next scheduled update",
@@ -113,7 +127,7 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
             except MontaApiClientError as exception:
                 raise UpdateFailed(exception) from exception
             self._backfilled_charge_points.add(charge_point_id)
-            charge_points[charge_point_id].charges = backfill
+            charge_points[charge_point_id].charges = fetched
 
         return charge_points
 

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -11,6 +11,7 @@ from monta import (
     MontaApiClient,
     MontaApiClientAuthenticationError,
     MontaApiClientError,
+    MontaApiClientRateLimitError,
 )
 from monta.models import Charge, ChargePoint, Wallet, WalletTransaction
 
@@ -19,6 +20,19 @@ from .const import DOMAIN, LOGGER
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+
+# Latest charges fetched per update cycle, across all charge points.
+CHARGES_PER_UPDATE = 100
+
+
+def _rate_limit_message(exception: MontaApiClientRateLimitError) -> str:
+    """Build an UpdateFailed message for a rate-limited request."""
+    if exception.retry_after is not None:
+        return (
+            "Monta API rate limit hit, API asks to retry after "
+            f"{exception.retry_after}s; retrying on the next scheduled update"
+        )
+    return "Monta API rate limit hit; retrying on the next scheduled update"
 
 
 class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]]):
@@ -43,19 +57,39 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
         )
 
     async def _async_update_data(self) -> dict[int, ChargePoint]:
-        """Update charge point data via library."""
+        """Update charge point data via library.
+
+        Uses two requests per cycle regardless of charger count: one
+        paginated charge-point fetch and one bulk charges fetch, so accounts
+        with many chargers stay under Monta's ~10 requests/minute limit.
+        """
         try:
-            charge_points = await self.client.async_get_charge_points()
-            for charge_point_id in charge_points:
-                charge_points[
-                    charge_point_id
-                ].charges = await self.client.async_get_charges(charge_point_id)
+            charge_points = await self.client.async_get_all_charge_points()
+            charges = await self.client.async_get_charges(
+                per_page=CHARGES_PER_UPDATE,
+            )
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientRateLimitError as exception:
+            raise UpdateFailed(_rate_limit_message(exception)) from exception
         except MontaApiClientError as exception:
             raise UpdateFailed(exception) from exception
-        else:
-            return charge_points
+
+        charges_by_charge_point: dict[int, list[Charge]] = {}
+        for charge in charges:
+            charges_by_charge_point.setdefault(
+                charge.charge_point_id, [],
+            ).append(charge)
+
+        for charge_point_id, charge_point in charge_points.items():
+            if charge_point_id in charges_by_charge_point:
+                charge_point.charges = charges_by_charge_point[charge_point_id]
+            elif self.data and charge_point_id in self.data:
+                # A charger with no charge in the latest batch keeps the
+                # charges from the previous cycle instead of going empty.
+                charge_point.charges = self.data[charge_point_id].charges
+
+        return charge_points
 
     async def async_start_charge(self, charge_point_id: int) -> Charge:
         """Start a charge."""
@@ -63,6 +97,8 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
             return await self.client.async_start_charge(charge_point_id)
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientRateLimitError as exception:
+            raise UpdateFailed(_rate_limit_message(exception)) from exception
         except MontaApiClientError as exception:
             raise UpdateFailed(exception) from exception
 
@@ -78,6 +114,8 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
             return await self.client.async_stop_charge(charges[0].id)
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientRateLimitError as exception:
+            raise UpdateFailed(_rate_limit_message(exception)) from exception
         except MontaApiClientError as exception:
             raise UpdateFailed(exception) from exception
 
@@ -109,6 +147,8 @@ class MontaWalletCoordinator(DataUpdateCoordinator[Wallet]):
             return await self.client.async_get_personal_wallet()
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientRateLimitError as exception:
+            raise UpdateFailed(_rate_limit_message(exception)) from exception
         except MontaApiClientError as exception:
             raise UpdateFailed(exception) from exception
 
@@ -140,5 +180,7 @@ class MontaTransactionCoordinator(DataUpdateCoordinator[list[WalletTransaction]]
             return await self.client.async_get_wallet_transactions()
         except MontaApiClientAuthenticationError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientRateLimitError as exception:
+            raise UpdateFailed(_rate_limit_message(exception)) from exception
         except MontaApiClientError as exception:
             raise UpdateFailed(exception) from exception

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -49,6 +49,7 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
     ) -> None:
         """Initialize."""
         self.client = client
+        self._backfilled_charge_points: set[int] = set()
         super().__init__(
             hass=hass,
             logger=LOGGER,
@@ -61,7 +62,10 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
 
         Uses two requests per cycle regardless of charger count: one
         paginated charge-point fetch and one bulk charges fetch, so accounts
-        with many chargers stay under Monta's ~10 requests/minute limit.
+        with many chargers stay under Monta's ~10 requests/minute limit. A
+        charger whose last charge is older than the whole bulk batch gets one
+        targeted fetch, once per charger, so its last-charge sensors still
+        populate.
         """
         try:
             charge_points = await self.client.async_get_all_charge_points()
@@ -81,15 +85,43 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
                 charge.charge_point_id, [],
             ).append(charge)
 
+        needs_backfill: list[int] = []
         for charge_point_id, charge_point in charge_points.items():
             if charge_point_id in charges_by_charge_point:
                 charge_point.charges = charges_by_charge_point[charge_point_id]
-            elif self.data and charge_point_id in self.data:
+            elif previous_charges := self._previous_charges(charge_point_id):
                 # A charger with no charge in the latest batch keeps the
                 # charges from the previous cycle instead of going empty.
-                charge_point.charges = self.data[charge_point_id].charges
+                charge_point.charges = previous_charges
+            elif charge_point_id not in self._backfilled_charge_points:
+                needs_backfill.append(charge_point_id)
+
+        for charge_point_id in needs_backfill:
+            try:
+                backfill = await self.client.async_get_charges(charge_point_id)
+            except MontaApiClientAuthenticationError as exception:
+                raise ConfigEntryAuthFailed(exception) from exception
+            except MontaApiClientRateLimitError:
+                # Keep the bulk data already gathered; chargers not yet
+                # backfilled stay pending and are retried next cycle.
+                LOGGER.warning(
+                    "Rate limited while fetching charges for charge point "
+                    "%s; retrying on the next scheduled update",
+                    charge_point_id,
+                )
+                break
+            except MontaApiClientError as exception:
+                raise UpdateFailed(exception) from exception
+            self._backfilled_charge_points.add(charge_point_id)
+            charge_points[charge_point_id].charges = backfill
 
         return charge_points
+
+    def _previous_charges(self, charge_point_id: int) -> list[Charge]:
+        """Return the charges fetched for a charge point in earlier cycles."""
+        if self.data and charge_point_id in self.data:
+            return self.data[charge_point_id].charges
+        return []
 
     async def async_start_charge(self, charge_point_id: int) -> Charge:
         """Start a charge."""

--- a/custom_components/monta/manifest.json
+++ b/custom_components/monta/manifest.json
@@ -14,7 +14,7 @@
     "monta"
   ],
   "requirements": [
-    "monta==1.0.4"
+    "monta==1.1.0"
   ],
   "version": "1.3.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ homeassistant==2025.11.0
 ruff==0.16.0
 pip>=26.1.2,<26.2
 debugpy==1.8.21
-monta==1.0.6
+monta==1.1.0


### PR DESCRIPTION
## Problem

Each charge-point update cycle issued 1 list call plus 1 `async_get_charges` detail call per charger, back-to-back. On accounts with several chargers that burst exceeds Monta's ~10 requests/min limit and the update fails with HTTP 429 (see #295). The list call was also capped at the API's default page size of 10, so accounts with more than 10 chargers silently lost the rest.

## Change

The coordinator now makes 2 requests per cycle in the steady state, regardless of charger count:

- One paginated charge-point fetch via `async_get_all_charge_points()` (new in monta 1.1.0), fixing the >10 charger cap
- One bulk `async_get_charges(per_page=100)` call, grouped by `charge_point_id` and assigned to each charge point

Chargers absent from the bulk batch are handled by how their data can change:

- A retained charge in a terminal state (`stopped`/`completed`) never goes stale, since any state change comes from a newer charge that is guaranteed to enter the batch, so it's kept from the previous cycle with no extra request
- A charger never seen with a charge gets one targeted `async_get_charges(charge_point_id)` backfill call, once per charger
- A charger whose latest known charge is still active (the record mutates server-side) is refetched each cycle until it reaches a terminal state

A 429 during these targeted fetches is degraded gracefully: the bulk data is kept, a warning is logged, and the remaining chargers are retried on the next cycle.

All coordinator call sites now catch `MontaApiClientRateLimitError` (monta 1.0.6+) explicitly and raise `UpdateFailed` with the `Retry-After` hint in the message, so a rate-limited cycle logs clearly and simply retries on the next scheduled update. No throttling delay to configure, and setup/reload no longer scales with charger count.

- `manifest.json` bumped from the stale `monta==1.0.4` to `monta==1.1.0` (published on PyPI), `requirements.txt` from 1.0.6 to 1.1.0

Supersedes #295.

## Testing

Ruff passes. Verified `_async_update_data` with a mocked client across five scenarios: bulk grouping per charger (newest first) with previous-cycle retention, an account where one charger's 100+ charges push another charger's old completed charge out of the batch (backfilled with exactly one extra call, not repeated), a charger with genuinely zero charges (backfilled once, then never again), a 429 mid-backfill (bulk data kept, backfill retried and completed the next cycle), and a long-running active charge outside the batch (refetched every cycle until it completes, then retained without further calls). The library's pagination loop is covered in nickknissen/monta-python#13.