### PR TITLE
Add energy sensors that track during an active charge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Platform | Description
 `switch` | Switch something `True` or `False`.
 `services` | `start_charging` and `stop_charging``
 
+### Energy dashboard
+
+Use the **Meter Reading** sensor. It is derived from the charge in progress, so it advances while
+the car is charging.
+
+**Last Meter Reading** is the `lastMeterReadingKwh` value exactly as Monta returns it. Monta only
+refreshes it once the cable is unplugged, so on the Energy dashboard a whole session shows up as a
+single spike at the end.
+
+**Charge Energy** is the energy delivered by the current charge, and resets when a new charge
+starts.
+
 ## Installation
 
 

--- a/custom_components/monta/sensor.py
+++ b/custom_components/monta/sensor.py
@@ -84,6 +84,23 @@ def last_charge_extra_attributes(data: ChargePoint) -> dict[str, Any] | None:
     return None
 
 
+def charge_meter_reading(data: ChargePoint) -> float | None:
+    """Process the meter reading, including the charge in progress.
+
+    lastMeterReadingKwh only refreshes once the cable is unplugged, so derive
+    the reading from the newest charge and fall back to the charge point's own
+    value when that charge carries no meter data.
+    """
+    if data.charges and (start := data.charges[0].start_meter_kwh) is not None:
+        return start + (data.charges[0].consumed_kwh or 0)
+    return data.last_meter_reading_kwh
+
+
+def charge_consumed_kwh(data: ChargePoint) -> float | None:
+    """Process energy delivered by the newest charge, while it is running."""
+    return data.charges[0].consumed_kwh if data.charges else None
+
+
 def wallet_credit_extra_attribute(data: Wallet) -> dict[str, Any] | None:
     """Process extra attributes for last charge (if available)."""
     if data.balance:
@@ -155,6 +172,28 @@ CHARGE_POINT_ENTITY_DESCRIPTIONS: tuple[MontaSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.MONETARY,
         value_fn=last_charge_cost,
         unit_fn=last_charge_currency,
+        extra_state_attributes_fn=None,
+    ),
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
+        key="charge_meter_reading",
+        translation_key="charge_meter_reading",
+        icon="mdi:counter",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=3,
+        value_fn=charge_meter_reading,
+        extra_state_attributes_fn=None,
+    ),
+    MontaSensorEntityDescription(  # pylint: disable=unexpected-keyword-arg
+        key="charge_energy",
+        translation_key="charge_energy",
+        icon="mdi:lightning-bolt",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=3,
+        value_fn=charge_consumed_kwh,
         extra_state_attributes_fn=None,
     ),
 )

--- a/custom_components/monta/translations/da.json
+++ b/custom_components/monta/translations/da.json
@@ -122,6 +122,12 @@
       },
       "charge_cost": {
         "name": "Sidste opladnings pris"
+      },
+      "charge_meter_reading": {
+        "name": "Måleraflæsning"
+      },
+      "charge_energy": {
+        "name": "Opladningsenergi"
       }
     }
   }

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -122,6 +122,12 @@
       },
       "charge_cost": {
         "name": "Last Charge Cost"
+      },
+      "charge_meter_reading": {
+        "name": "Meter Reading"
+      },
+      "charge_energy": {
+        "name": "Charge Energy"
       }
     }
   }

--- a/custom_components/monta/translations/pt.json
+++ b/custom_components/monta/translations/pt.json
@@ -114,6 +114,12 @@
       },
       "charge_cost": {
         "name": "Custo do Último Carregamento"
+      },
+      "charge_meter_reading": {
+        "name": "Leitura do Medidor"
+      },
+      "charge_energy": {
+        "name": "Energia do Carregamento"
       }
     }
   }


### PR DESCRIPTION
Closes #308.

## Why

`Last Meter Reading` surfaces `lastMeterReadingKwh` from `/charge-points`, which Monta only refreshes once the cable is unplugged. On the Energy dashboard that means a whole charging session shows up as a single spike at the end. Closed issue #281 was the same complaint from a different angle.

## What

Two new per-charger sensors, both `ENERGY` / `TOTAL_INCREASING`:

| Sensor | Value | Behaviour |
|---|---|---|
| **Meter Reading** | `charges[0].start_meter_kwh + consumed_kwh` | Advances during a charge, flat between charges. Use this on the Energy dashboard. |
| **Charge Energy** | `charges[0].consumed_kwh` | Energy delivered by the current charge, resets each session. |

`Last Meter Reading` is deliberately left untouched as the raw API passthrough.

The issue suggested calling `/charges?state=charging`, but that isn't needed. `MontaChargePointCoordinator._async_update_data` already fetches the 100 newest charges in bulk each cycle and attaches them to each `ChargePoint.charges`. An in-progress charge always has the highest id, so it's always in that batch. **This costs zero extra API calls**, which matters against the ~10 req/min limit.

`Meter Reading` falls back to `last_meter_reading_kwh` when the newest charge has no `startMeterKwh` (a failed or cancelled charge), which would otherwise blank the sensor.

## Verified

- Value functions exercised against real `monta` model objects across six cases: idle, mid-charge, charge started with `consumedKwh` still null, failed charge with no meter data, no charges, and no charges with no meter reading.
- Monotonic across a session boundary: `[1050.0, 1050.0, 1058.0, 1069.3, 1069.3]`. No downward step when `lastMeterReadingKwh` catches up at unplug, so no false statistics reset. This is the property `TOTAL_INCREASING` needs.
- All 8 charge-point sensors produce distinct unique IDs; the new keys don't collide with `charger_last_meter_reading_kwh`.
- `ruff check .` clean, all three translation files parse.

## Not verified

**That Monta actually updates `consumedKwh` server-side mid-charge.** 