### PR TITLE
Scope the token store per config entry and stop wiping it

### DIFF
--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, Platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.storage import Store
 from monta import MontaApiClient
 
 from .const import (
@@ -21,8 +20,6 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
     DEFAULT_SCAN_INTERVAL_WALLET,
     DOMAIN,
-    STORAGE_KEY,
-    STORAGE_VERSION,
 )
 from .coordinator import (
     MontaChargePointCoordinator,
@@ -30,7 +27,11 @@ from .coordinator import (
     MontaWalletCoordinator,
 )
 from .services import async_setup_services
-from .storage import HomeAssistantTokenStorage
+from .storage import (
+    HomeAssistantTokenStorage,
+    async_get_token_store,
+    async_remove_legacy_token_store,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -48,8 +49,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
     hass.data.setdefault(DOMAIN, {})
 
-    store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
-    await store.async_remove()
+    await async_remove_legacy_token_store(hass)
+    store = async_get_token_store(hass, entry.entry_id)
 
     # Get individual scan intervals for each data type
     scan_interval_charge_points = entry.options.get(
@@ -121,6 +122,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unloaded := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unloaded
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Discard the entry's cached tokens when the entry is deleted."""
+    await async_get_token_store(hass, entry.entry_id).async_remove()
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -9,7 +9,6 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from homeassistant.helpers.storage import Store
 from monta import (
     MontaApiClient,
     MontaApiClientAuthenticationError,
@@ -26,10 +25,8 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_WALLET,
     DOMAIN,
     LOGGER,
-    STORAGE_KEY,
-    STORAGE_VERSION,
 )
-from .storage import HomeAssistantTokenStorage
+from .storage import async_get_token_store
 
 if TYPE_CHECKING:
     from monta.models import TokenResponse
@@ -137,7 +134,7 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,  # noqa: ARG004
+        _config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Get the options flow for this handler."""
         return MontaOptionsFlowHandler()
@@ -146,13 +143,12 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, client_id: str, client_secret: str,
     ) -> TokenResponse:
         """Validate credentials."""
+        # No token storage: requesting a token here must not touch the tokens
+        # cached for an existing entry.
         client = MontaApiClient(
             client_id=client_id,
             client_secret=client_secret,
             session=async_create_clientsession(self.hass),
-            token_storage=HomeAssistantTokenStorage(
-                Store(self.hass, STORAGE_VERSION, STORAGE_KEY),
-            ),
         )
         return await client.async_request_token()
 
@@ -195,6 +191,11 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                 ) or user_input.get(CONF_CLIENT_SECRET) != self.config_entry.data.get(
                     CONF_CLIENT_SECRET,
                 ):
+                    # Drop the cached tokens before the entry reloads with the
+                    # new credentials, they belong to the old ones.
+                    await async_get_token_store(
+                        self.hass, self.config_entry.entry_id,
+                    ).async_remove()
                     self.hass.config_entries.async_update_entry(
                         self.config_entry,
                         data={
@@ -259,12 +260,11 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
         self, client_id: str, client_secret: str,
     ) -> TokenResponse:
         """Validate credentials."""
+        # No token storage: validating here must not overwrite the tokens
+        # cached for this entry, which still belong to the old credentials.
         client = MontaApiClient(
             client_id=client_id,
             client_secret=client_secret,
             session=async_create_clientsession(self.hass),
-            token_storage=HomeAssistantTokenStorage(
-                Store(self.hass, STORAGE_VERSION, STORAGE_KEY),
-            ),
         )
         return await client.async_request_token()

--- a/custom_components/monta/storage.py
+++ b/custom_components/monta/storage.py
@@ -4,10 +4,28 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.helpers.storage import Store
 from monta import TokenStorage
 
+from .const import STORAGE_KEY, STORAGE_VERSION
+
 if TYPE_CHECKING:
-    from homeassistant.helpers.storage import Store
+    from homeassistant.core import HomeAssistant
+
+
+def async_get_token_store(hass: HomeAssistant, entry_id: str) -> Store:
+    """Return the token store belonging to a single config entry.
+
+    Each config entry authenticates as its own Monta account, so the tokens
+    must not be shared: a shared store lets one entry pick up (and refresh
+    away) another entry's tokens.
+    """
+    return Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{entry_id}")
+
+
+async def async_remove_legacy_token_store(hass: HomeAssistant) -> None:
+    """Remove the pre-per-entry token store left behind by older versions."""
+    await Store(hass, STORAGE_VERSION, STORAGE_KEY).async_remove()
 
 
 class HomeAssistantTokenStorage(TokenStorage):


### PR DESCRIPTION
Fixes #309. Both claims in the issue hold up; details below.

## What was wrong

`STORAGE_KEY = "monta_auth"` is a fixed string, and `async_setup_entry` opened that store only to delete it:

```python
store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
await store.async_remove()
```

**Tokens never persisted.** `Store.async_remove()` unlinks `.storage/monta_auth`, and `async_reload_entry` re-enters `async_setup_entry`, so every restart, reload and options change discarded the cached access *and* refresh tokens. Nothing broke, since the client falls back to client id/secret, but the storage was effectively write-only and each setup burned an extra `auth/token` request per entry, on an API this integration already has rate-limit workarounds for.

**Multiple entries shared one file.** The config flow sets no unique id and the manifest has no `single_config_entry`, so two accounts are allowed, and both got the same store. `_is_access_token_valid` only checks expiry, never which credentials a token belongs to, so an entry that loads the file finds another account's valid token and sends it as its own bearer. Verified against `monta==1.1.0` with two clients over one shared file:

```
token entry B will send as Bearer: ACCESS-TOKEN-OF-ACCOUNT-A
CROSS-ACCOUNT LEAK: True
```

This is not a narrow race. Home Assistant sets up all entries of a domain concurrently (`asyncio.gather` over `async_setup_locked`), and each client caches `_token_data` in memory after its single load, so once an entry picks up the wrong token it keeps using it until expiry, then calls `auth/refresh` with the other account's refresh token and rotates it away, breaking that entry too.

## What changed

`storage.py` now owns every use of the storage key:

- `async_get_token_store(hass, entry_id)` returns a store keyed `monta_auth_<entry_id>`, so entries cannot see each other's tokens.
- `async_remove_legacy_token_store(hass)` deletes the now-orphaned global `monta_auth` file, which otherwise sits in `.storage` holding live tokens.

The unconditional removal is gone from setup, and cleanup moved to the places that actually mean "these tokens are dead":

- `async_remove_entry` discards the entry's tokens when the entry is deleted.
- The options flow discards them when the credentials change, since the cached tokens belong to the old account. The wipe runs *before* `async_update_entry` so it cannot race the reload task that call schedules.

Both `_test_credentials` methods no longer pass a `token_storage`: `async_request_token` never wrote to it, so those `Store` instances were dead weight. Also renamed the unused `config_entry` parameter of `async_get_options_flow` to `_config_entry` and dropped its `# noqa: ARG004` (Home Assistant passes it positionally, and this repo's ruff config does not even select `ARG`).

## Verification

| Behavior | Before | After |
| --- | --- | --- |
| Tokens after reload/restart | `access_token: None` | reused |
| Entry B's first token load | account A's token | `None`, authenticates as itself |
| Removing entry A | leaves `monta_auth` behind | A's store gone, B's untouched |

