### PR TITLE
Register services once instead of per config entry

### DIFF
--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -26,7 +26,7 @@ from .coordinator import (
     MontaTransactionCoordinator,
     MontaWalletCoordinator,
 )
-from .services import async_setup_services
+from .services import async_setup_services, async_unload_services
 from .storage import (
     HomeAssistantTokenStorage,
     async_get_token_store,
@@ -110,7 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    await async_setup_services(hass, entry)
+    async_setup_services(hass)
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -121,6 +121,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
     if unloaded := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            # The services are shared by all entries, so they outlive any
+            # single one of them.
+            async_unload_services(hass)
     return unloaded
 
 

--- a/custom_components/monta/services.py
+++ b/custom_components/monta/services.py
@@ -1,96 +1,116 @@
-"""Monta components services."""
+"""Monta components services.
+
+The services are registered once for the whole integration, not once per
+config entry: registration is keyed by (domain, service), so a per-entry
+registration would silently replace the previous entry's handler. The entry
+that owns a charge point is therefore resolved per call instead of being
+captured at registration time.
+"""
+
+from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+    from .coordinator import MontaChargePointCoordinator
+
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_START_CHARGING = "start_charging"
+SERVICE_STOP_CHARGING = "stop_charging"
 
 has_id_schema = vol.Schema({vol.Required("charge_point_id"): int})
 
 
-async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Set up services for the Monta component."""
+def _resolve_coordinator(
+    hass: HomeAssistant,
+    charge_point_id: int,
+) -> MontaChargePointCoordinator:
+    """Return the coordinator of the entry that owns this charge point."""
+    for entry_data in hass.data.get(DOMAIN, {}).values():
+        coordinator = entry_data["charge_point"]
+        if coordinator.data and charge_point_id in coordinator.data:
+            return coordinator
+
+    msg = f"Charge point {charge_point_id} not found"
+    raise HomeAssistantError(msg)
+
+
+def _state_error_message(
+    action: str,
+    charge_point_state: str,
+    expected_state: str,
+) -> HomeAssistantError:
+    msg = (
+        f"Cannot {action} charging. "
+        f"Charger is in state '{charge_point_state}'. Expected: {expected_state}"
+    )
+    return HomeAssistantError(msg)
+
+
+async def _service_handle_start_charging(service_call: ServiceCall) -> None:
+    """Handle the start charging service call."""
+    charge_point_id = service_call.data["charge_point_id"]
+    _LOGGER.debug("Called start charging for %s", charge_point_id)
+
+    coordinator = _resolve_coordinator(service_call.hass, charge_point_id)
+
+    charge_point_state = coordinator.data[charge_point_id].state
+    if charge_point_state != "available":
+        raise _state_error_message("start", charge_point_state, "available")
+
+    await coordinator.async_start_charge(charge_point_id)
+    _LOGGER.info(
+        "Successfully started charging for charge point %s",
+        charge_point_id,
+    )
+
+
+async def _service_handle_stop_charging(service_call: ServiceCall) -> None:
+    """Handle the stop charging service call."""
+    charge_point_id = service_call.data["charge_point_id"]
+    _LOGGER.debug("Called stop charging for %s", charge_point_id)
+
+    coordinator = _resolve_coordinator(service_call.hass, charge_point_id)
+
+    charge_point_state = coordinator.data[charge_point_id].state
+    if not charge_point_state.startswith("busy"):
+        raise _state_error_message("stop", charge_point_state, "busy")
+
+    await coordinator.async_stop_charge(charge_point_id)
+    _LOGGER.info(
+        "Successfully stopped charging for charge point %s",
+        charge_point_id,
+    )
+
+
+# LIST OF SERVICES
+SERVICES: list[tuple[str, vol.Schema, Any]] = [
+    (SERVICE_START_CHARGING, has_id_schema, _service_handle_start_charging),
+    (SERVICE_STOP_CHARGING, has_id_schema, _service_handle_stop_charging),
+]
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the Monta services, once for all config entries."""
+    if hass.services.has_service(DOMAIN, SERVICE_START_CHARGING):
+        return
+
     _LOGGER.debug("Set up services")
-
-    coordinators = hass.data[DOMAIN][entry.entry_id]
-    charge_point_coordinator = coordinators["charge_point"]
-
-    async def service_handle_stop_charging(service_call: ServiceCall) -> None:
-        """Handle the stop charging service call."""
-        charge_point_id = service_call.data["charge_point_id"]
-        _LOGGER.debug("Called stop charging for %s", charge_point_id)
-
-        # Check if charge point exists
-        if charge_point_id not in charge_point_coordinator.data:
-            msg = f"Charge point {charge_point_id} not found"
-            raise HomeAssistantError(msg)
-
-        charge_point_state = charge_point_coordinator.data[charge_point_id].state
-        if charge_point_state.startswith("busy"):
-            await charge_point_coordinator.async_stop_charge(charge_point_id)
-            _LOGGER.info(
-                "Successfully stopped charging for charge point %s",
-                charge_point_id,
-            )
-            return
-
-        action = "stop"
-        raise state_error_message(
-            action,
-            charge_point_state,
-            "busy",
-        )
-
-    async def service_handle_start_charging(service_call: ServiceCall) -> None:
-        """Handle the start charging service call."""
-        charge_point_id = service_call.data["charge_point_id"]
-        _LOGGER.debug("Called start charging for %s", charge_point_id)
-
-        # Check if charge point exists
-        if charge_point_id not in charge_point_coordinator.data:
-            msg = f"Charge point {charge_point_id} not found"
-            raise HomeAssistantError(msg)
-
-        charge_point_state = charge_point_coordinator.data[charge_point_id].state
-        if charge_point_state == "available":
-            await charge_point_coordinator.async_start_charge(charge_point_id)
-            _LOGGER.info(
-                "Successfully started charging for charge point %s",
-                charge_point_id,
-            )
-            return
-
-        action = "start"
-        raise state_error_message(
-            action,
-            charge_point_state,
-            "available",
-        )
-
-    def state_error_message(
-        action: str,
-        charge_point_state: str,
-        expected_state: str,
-    ) -> HomeAssistantError:
-        msg = (
-            f"Cannot {action} charging. "
-            f"Charger is in state '{charge_point_state}'. Expected: {expected_state}"
-        )
-        return HomeAssistantError(msg)
-
-    # LIST OF SERVICES
-    services: list[tuple[str, vol.Schema, Any]] = [
-        ("start_charging", has_id_schema, service_handle_start_charging),
-        ("stop_charging", has_id_schema, service_handle_stop_charging),
-    ]
-
-    # Register the services
-    for name, schema, handler in services:
+    for name, schema, handler in SERVICES:
         hass.services.async_register(DOMAIN, name, handler, schema=schema)
+
+
+def async_unload_services(hass: HomeAssistant) -> None:
+    """Remove the Monta services, once the last config entry is unloaded."""
+    _LOGGER.debug("Remove services")
+    for name, _schema, _handler in SERVICES:
+        hass.services.async_remove(DOMAIN, name)


### PR DESCRIPTION
Fixes #310. All four claims in the issue hold up.

## What was wrong

`async_setup_services(hass, entry)` ran once per config entry, and its two handlers closed over that entry's `charge_point` coordinator. Registration is keyed by `(domain, service)`, and `ServiceRegistry._async_register` overwrites the existing entry with no warning:

```python
if domain in self._services:
    self._services[domain][service] = service_obj
```

So with two entries, `monta.start_charging` and `monta.stop_charging` both belonged to whichever entry set up last, and calling them for a charger on the other account hit the `Charge point N not found` guard. Because Home Assistant sets up an integration's entries concurrently, which entry won was not stable across restarts.

`async_unload_entry` also never called `hass.services.async_remove`, so after unloading an entry the services stayed registered, holding a coordinator whose entry had already been popped from `hass.data`. A single-entry reload happened to paper over this by re-registering, but disabling or removing an entry left the zombie behind.

## What changed

- The services are registered once for the whole integration, guarded by `has_service`. Later entries setting up no longer replace the handlers.
- The owning entry is resolved per call: `_resolve_coordinator` walks `hass.data[DOMAIN]` and returns the coordinator whose data contains the requested charge point, raising the same `Charge point N not found` error when no entry owns it. It also tolerates `coordinator.data` still being `None`, which is the state of an entry whose first refresh failed.
- `async_unload_entry` removes the services once the last entry is gone.
- Handlers moved to module level, since there is no longer any per-entry state to close over. Both are now `async_setup_services(hass)` / `async_unload_services(hass)`, sync functions that only touch the service registry.

State guards and error messages are unchanged. They are inverted to fail fast rather than returning from inside the happy path, which is why the diff looks larger than the behavior change.

## Verification

Drove the new module directly with two fake entries (`entry-A` owning chargers 1 and 2, `entry-B` owning 7 and 8):

| Check | Result |
| --- | --- |
| Charger on the first entry | dispatches to entry A, entry B untouched |
| Charger on the second entry | dispatches to entry B (previously `Charge point 7 not found`) |
| Unknown charger | `Charge point 99 not found` |
| Start on `busy-charging` | `Cannot start charging. Charger is in state 'busy-charging'. Expected: available` |
| Stop on `available` | `Cannot stop charging. Charger is in state 'available'. Expected: busy` |
| Second entry setting up | both services present, handlers not replaced |
| Last entry unloading | both services removed |

Ruff passes and the package compiles. As with #309 this is not a booted Home Assistant: `pytest-homeassistant-custom-component` is not installed and no tests are tracked in the repo, so the registry and coordinators were faked.

## Not addressed here

`services.yaml` still declares `charge_point_id` with a device selector while the schema requires an int. That is #311 and is left alone.
