### PR TITLE
Accept the device id the service picker sends

### DIFF
--- a/custom_components/monta/services.py
+++ b/custom_components/monta/services.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
 
@@ -27,7 +28,34 @@ _LOGGER = logging.getLogger(__name__)
 SERVICE_START_CHARGING = "start_charging"
 SERVICE_STOP_CHARGING = "stop_charging"
 
-has_id_schema = vol.Schema({vol.Required("charge_point_id"): int})
+# The UI picker hands over a Home Assistant device id, while automations pass
+# the numeric Monta charge point id. Both are accepted and normalised by
+# _resolve_charge_point_id.
+has_id_schema = vol.Schema(
+    {vol.Required("charge_point_id"): vol.Any(vol.Coerce(int), str)},
+)
+
+
+def _resolve_charge_point_id(hass: HomeAssistant, value: int | str) -> int:
+    """Return the Monta charge point id for a service call field value.
+
+    The field accepts the numeric charge point id, as used by existing
+    automations, or the device id the UI service picker sends.
+    """
+    if isinstance(value, int):
+        return value
+
+    device = dr.async_get(hass).async_get(value)
+    if device is None:
+        msg = f"Device {value} not found"
+        raise HomeAssistantError(msg)
+
+    for domain, identifier in device.identifiers:
+        if domain == DOMAIN and identifier.isdigit():
+            return int(identifier)
+
+    msg = f"Device {device.name or value} is not a Monta charge point"
+    raise HomeAssistantError(msg)
 
 
 def _resolve_coordinator(
@@ -58,7 +86,9 @@ def _state_error_message(
 
 async def _service_handle_start_charging(service_call: ServiceCall) -> None:
     """Handle the start charging service call."""
-    charge_point_id = service_call.data["charge_point_id"]
+    charge_point_id = _resolve_charge_point_id(
+        service_call.hass, service_call.data["charge_point_id"],
+    )
     _LOGGER.debug("Called start charging for %s", charge_point_id)
 
     coordinator = _resolve_coordinator(service_call.hass, charge_point_id)
@@ -76,7 +106,9 @@ async def _service_handle_start_charging(service_call: ServiceCall) -> None:
 
 async def _service_handle_stop_charging(service_call: ServiceCall) -> None:
     """Handle the stop charging service call."""
-    charge_point_id = service_call.data["charge_point_id"]
+    charge_point_id = _resolve_charge_point_id(
+        service_call.hass, service_call.data["charge_point_id"],
+    )
     _LOGGER.debug("Called stop charging for %s", charge_point_id)
 
     coordinator = _resolve_coordinator(service_call.hass, charge_point_id)

--- a/custom_components/monta/services.yaml
+++ b/custom_components/monta/services.yaml
@@ -5,11 +5,16 @@ start_charging:
     specify the charge_point_id directly
   fields:
     charge_point_id:
-      description: "The charger point id"
+      name: Charger
+      description: >-
+        The charger. Pick one from the list, or pass the numeric Monta
+        charge point id.
+      example: 12345
       required: true
       selector:
         device:
-          integration: monta
+          filter:
+            integration: monta
 
 stop_charging:
   name: Stop charging
@@ -18,8 +23,13 @@ stop_charging:
     or specify the charge_point_id directly
   fields:
     charge_point_id:
-      description: "The charger point id"
+      name: Charger
+      description: >-
+        The charger. Pick one from the list, or pass the numeric Monta
+        charge point id.
+      example: 12345
       required: true
       selector:
         device:
-          integration: monta
+          filter:
+            integration: monta

--- a/custom_components/monta/strings.json
+++ b/custom_components/monta/strings.json
@@ -58,8 +58,8 @@
 			"name": "Start charging",
 			"fields": {
 				"charge_point_id": {
-					"name": "Charge Point ID",
-					"description": "The ID of the charger."
+					"name": "Charger",
+					"description": "The charger. Pick one from the list, or pass the numeric Monta charge point ID."
 				}
 			}
 		},
@@ -68,8 +68,8 @@
 			"name": "Stop charging",
 			"fields": {
 				"charge_point_id": {
-					"name": "Charge Point ID",
-					"description": "The ID of the charger."
+					"name": "Charger",
+					"description": "The charger. Pick one from the list, or pass the numeric Monta charge point ID."
 				}
 			}
 		}

--- a/custom_components/monta/translations/da.json
+++ b/custom_components/monta/translations/da.json
@@ -58,8 +58,8 @@
       "name": "Start opladning",
       "fields": {
         "charge_point_id": {
-          "name": "Ladepunkt-ID",
-          "description": "ID'et for laderen."
+          "name": "Lader",
+          "description": "Laderen. Vælg en fra listen, eller angiv det numeriske Monta-ladepunkt-ID."
         }
       }
     },
@@ -68,8 +68,8 @@
       "name": "Stop opladning",
       "fields": {
         "charge_point_id": {
-          "name": "Ladepunkt-ID",
-          "description": "ID'et for laderen."
+          "name": "Lader",
+          "description": "Laderen. Vælg en fra listen, eller angiv det numeriske Monta-ladepunkt-ID."
         }
       }
     }

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -58,8 +58,8 @@
       "name": "Start charging",
       "fields": {
         "charge_point_id": {
-          "name": "Charge Point ID",
-          "description": "The ID of the charger."
+          "name": "Charger",
+          "description": "The charger. Pick one from the list, or pass the numeric Monta charge point ID."
         }
       }
     },
@@ -68,8 +68,8 @@
       "name": "Stop charging",
       "fields": {
         "charge_point_id": {
-          "name": "Charge Point ID",
-          "description": "The ID of the charger."
+          "name": "Charger",
+          "description": "The charger. Pick one from the list, or pass the numeric Monta charge point ID."
         }
       }
     }

--- a/custom_components/monta/translations/pt.json
+++ b/custom_components/monta/translations/pt.json
@@ -50,8 +50,8 @@
       "name": "Iniciar carregamento",
       "fields": {
         "charge_point_id": {
-          "name": "ID do ponto de carregamento",
-          "description": "O ID do carregador."
+          "name": "Carregador",
+          "description": "O carregador. Escolha um da lista ou indique o ID numérico do ponto de carregamento da Monta."
         }
       }
     },
@@ -60,8 +60,8 @@
       "name": "Parar carregamento",
       "fields": {
         "charge_point_id": {
-          "name": "ID do ponto de carregamento",
-          "description": "O ID do carregador."
+          "name": "Carregador",
+          "description": "O carregador. Escolha um da lista ou indique o ID numérico do ponto de carregamento da Monta."
         }
       }
     }


### PR DESCRIPTION
Fixes #311. The claim holds, and it is slightly worse than reported.

## What was wrong

`services.yaml` declares `charge_point_id` with a `device` selector, so the UI service picker sends a Home Assistant device id string, while the schema was:

```python
has_id_schema = vol.Schema({vol.Required("charge_point_id"): int})
```

Voluptuous treats a bare `int` as a type check, not a coercion, so the picker's value never validated:

```
42                                 -> {'charge_point_id': 42}
'42'                               -> REJECTED: expected int for dictionary value
'a1b2c3d4e5f60718293a4b5c6d7e8f90' -> REJECTED: expected int for dictionary value
```

The middle line is the part the issue does not mention: a quoted id in YAML (`charge_point_id: "7"`) was rejected too. Only a bare integer worked.

## What changed

The field accepts either form and normalises it before anything else runs:

```python
has_id_schema = vol.Schema(
    {vol.Required("charge_point_id"): vol.Any(vol.Coerce(int), str)},
)
```

`_resolve_charge_point_id` then maps a device id to a charge point id through the device registry, matching the `(monta, str(charge_point_id))` identifier that `MontaEntity.device_info` registers (`entity.py:30-36`). An int passes straight through, so existing automations are untouched. The `isdigit()` guard means a non-numeric identifier is skipped rather than blowing up in `int()`.

The selector itself did not need to change for the fix: it only shapes the UI picker, it never validates, so the numeric form still works from YAML while the picker now works in the UI. That matches what the field description already promised.

## UI polish in the same PR

The field renders as a dropdown of Monta devices (`Monta - <charger name>`), so "Charge Point ID" no longer described it:

- Relabelled to **Charger** in `strings.json` and all three translations (`en`, `da`, `pt`), with a description that covers both accepted forms.
- Added `example: 12345` for the numeric form, which is what YAML-mode users see.
- Moved the selector from the legacy `device: integration:` form to `device: filter: integration:`. Both pass `selector.validate_selector`; the latter is what Home Assistant documents today.

`name`, `description` and `example` on a field are all accepted by hassfest for custom integrations, which is what this repo's CI runs.

## Verification

| Input | Result |
| --- | --- |
| `7` | `{'charge_point_id': 7}`, resolves to 7 |
| `'7'` | coerced to `7` |
| device id of `Monta - Garage` | resolves to charge point 7 via the registry |
| device id of a non-Monta device | `Device Kitchen light is not a Monta charge point` |
| unknown device id | `Device nope not found` |
| `None` | still rejected by the schema |

End to end, `start_charging` called with the picker's device id starts charger 7 on the entry that owns it.

`services.yaml` parses, `selector.validate_selector` accepts the new device filter, and all four translation files parse as valid UTF-8 with the Danish and Portuguese accents intact. Ruff passes and the package compiles. As with #309 and #310 the device registry and coordinators were faked, since `pytest-homeassistant-custom-component` is not installed and no tests are tracked in the repo.

## Note

A device id resolves to a charge point id, and the owning entry is then found by which coordinator holds that id, as introduced in #310. That indirection is only unambiguous while charge point ids are unique across accounts, which is the same assumption #312 is about.
