### PR TITLE
Add the reauth step the coordinators already ask for

### DIFF
--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -29,7 +29,27 @@ from .const import (
 from .storage import async_get_token_store
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
     from monta.models import TokenResponse
+
+
+def build_credentials_schema(defaults: dict) -> vol.Schema:
+    """Build a schema asking only for credentials, as reauthentication does."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_CLIENT_ID,
+                default=defaults.get(CONF_CLIENT_ID),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
+            ),
+            vol.Required(CONF_CLIENT_SECRET): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
+            ),
+        },
+    )
 
 
 def build_schema(defaults: dict) -> vol.Schema:
@@ -129,6 +149,57 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=build_schema(user_input or {}),
+            errors=_errors,
+        )
+
+    async def async_step_reauth(
+        self,
+        _entry_data: Mapping[str, Any],
+    ) -> config_entries.FlowResult:
+        """Handle credentials the API has stopped accepting.
+
+        Reached whenever a coordinator turns a 401 into ConfigEntryAuthFailed,
+        which makes Home Assistant start a reauth flow for the entry.
+        """
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self,
+        user_input: dict | None = None,
+    ) -> config_entries.FlowResult:
+        """Ask for working credentials and put them on the existing entry."""
+        entry = self._get_reauth_entry()
+        _errors = {}
+        if user_input is not None:
+            try:
+                await self._test_credentials(
+                    client_id=user_input[CONF_CLIENT_ID],
+                    client_secret=user_input[CONF_CLIENT_SECRET],
+                )
+            except MontaApiClientAuthenticationError as exception:
+                LOGGER.warning(exception)
+                _errors["base"] = "auth"
+            except MontaApiClientCommunicationError as exception:
+                LOGGER.error(exception)
+                _errors["base"] = "connection"
+            except MontaApiClientError as exception:
+                LOGGER.exception(exception)
+                _errors["base"] = "unknown"
+            else:
+                # Whatever is cached was minted for the old credentials.
+                await async_get_token_store(
+                    self.hass, entry.entry_id,
+                ).async_remove()
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=build_credentials_schema(
+                {CONF_CLIENT_ID: entry.data.get(CONF_CLIENT_ID)},
+            ),
             errors=_errors,
         )
 

--- a/custom_components/monta/strings.json
+++ b/custom_components/monta/strings.json
@@ -15,6 +15,14 @@
 					"scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
 					"scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
 				}
+			},
+			"reauth_confirm": {
+				"title": "Reauthenticate Monta",
+				"description": "The credentials for {name} are no longer accepted. Create or copy a new Client ID and Client Secret in CPMS: https://portal2.monta.app/applications",
+				"data": {
+					"client_id": "Client ID",
+					"client_secret": "Client Secret"
+				}
 			}
 		},
 		"error": {
@@ -23,7 +31,8 @@
 			"unknown": "Unknown error occurred."
 		},
 		"abort": {
-			"already_configured": "Device is already configured"
+			"already_configured": "Device is already configured",
+			"reauth_successful": "Monta reconnected with the new credentials"
 		}
 	},
 	"options": {

--- a/custom_components/monta/translations/da.json
+++ b/custom_components/monta/translations/da.json
@@ -15,6 +15,14 @@
           "scan_interval_wallet": "Hvor ofte tegnebogsdata skal hentes. Anbefalet: 600 sekunder (10 minutter)",
           "scan_interval_transactions": "Hvor ofte transaktionsdata skal hentes. Anbefalet: 600 sekunder (10 minutter)"
         }
+      },
+      "reauth_confirm": {
+        "title": "Godkend Monta igen",
+        "description": "Loginoplysningerne for {name} accepteres ikke længere. Opret eller kopier et nyt klient-ID og en ny klienthemmelighed i CPMS: https://portal2.monta.app/applications",
+        "data": {
+          "client_id": "Klient-ID",
+          "client_secret": "Klienthemmelighed"
+        }
       }
     },
     "error": {
@@ -23,7 +31,8 @@
       "unknown": "Der opstod en ukendt fejl."
     },
     "abort": {
-      "already_configured": "Enheden er allerede konfigureret"
+      "already_configured": "Enheden er allerede konfigureret",
+      "reauth_successful": "Monta er forbundet igen med de nye loginoplysninger"
     }
   },
   "options": {

--- a/custom_components/monta/translations/en.json
+++ b/custom_components/monta/translations/en.json
@@ -15,6 +15,14 @@
           "scan_interval_wallet": "How often to fetch wallet data. Recommended: 600 seconds (10 minutes)",
           "scan_interval_transactions": "How often to fetch transaction data. Recommended: 600 seconds (10 minutes)"
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Monta",
+        "description": "The credentials for {name} are no longer accepted. Create or copy a new Client ID and Client Secret in CPMS: https://portal2.monta.app/applications",
+        "data": {
+          "client_id": "Client ID",
+          "client_secret": "Client Secret"
+        }
       }
     },
     "error": {
@@ -23,7 +31,8 @@
       "unknown": "Unknown error occurred."
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Monta reconnected with the new credentials"
     }
   },
   "options": {

--- a/custom_components/monta/translations/pt.json
+++ b/custom_components/monta/translations/pt.json
@@ -15,12 +15,23 @@
           "scan_interval_wallet": "Com que frequência buscar dados da carteira. Recomendado: 600 segundos (10 minutos)",
           "scan_interval_transactions": "Com que frequência buscar dados de transações. Recomendado: 600 segundos (10 minutos)"
         }
+      },
+      "reauth_confirm": {
+        "title": "Autenticar novamente a Monta",
+        "description": "As credenciais de {name} já não são aceites. Crie ou copie um novo ID e segredo do cliente no CPMS: https://portal2.monta.app/applications",
+        "data": {
+          "client_id": "ID do cliente",
+          "client_secret": "Segredo do cliente"
+        }
       }
     },
     "error": {
       "auth": "ID do cliente/segredo do cliente está incorreto.",
       "connection": "Não foi possível ligar ao servidor.",
       "unknown": "Ocorreu um erro desconhecido."
+    },
+    "abort": {
+      "reauth_successful": "A Monta foi ligada novamente com as novas credenciais"
     }
   },
   "options": {


### PR DESCRIPTION
Fixes #313. The claim holds, and the failure is louder than "no step to run".

## What was wrong

The coordinators raise `ConfigEntryAuthFailed` on a 401, and `DataUpdateCoordinator` answers that by calling `self.config_entry.async_start_reauth(self.hass)` (`update_coordinator.py:451-466`). `MontaFlowHandler` only implemented `async_step_user`, and the base `ConfigFlow` has no `async_step_reauth`, so the flow manager hit:

```python
if not hasattr(flow, method):
    self._async_remove_flow_progress(flow.flow_id)
    raise UnknownStep(f"Handler {flow.__class__.__name__} doesn't support step {step_id}")
```

(`data_entry_flow.py:577-584`). So every authentication failure started a flow that was immediately discarded with `Handler MontaFlowHandler doesn't support step reauth`, leaving the entry stuck with no way to fix it except hunting down the options flow.

This is also the recovery path that #309 removed when it stopped wiping the token store on every setup, which I flagged there as the one regression that change left behind. It is now closed properly rather than by accident.

## What changed

`async_step_reauth` hands straight over to `async_step_reauth_confirm`, which:

- asks for a client id and secret only, so `build_credentials_schema` joins the existing `build_schema`, prefilling the current client id and leaving the secret blank;
- validates them through the same `_test_credentials` path as the user step, mapping the three Monta errors onto the existing `auth`, `connection` and `unknown` form errors;
- on success drops the entry's cached tokens, because they were minted for the credentials that just stopped working, then calls `async_update_reload_and_abort` with `data_updates` holding only the credentials, so the configured scan intervals survive and the entry reloads by itself.

Home Assistant fills the `{name}` placeholder in a reauth form with the entry title on its own (`config_entries.py:3369-3376`), so the prompt names the account that needs attention.

## Verification

Drove the handler directly with the Home Assistant plumbing stubbed:

| Step | Result |
| --- | --- |
| `async_step_reauth` | shows the `reauth_confirm` form, fields `['client_id', 'client_secret']` |
| Invalid credentials | form again with `{'base': 'auth'}`, entry not updated, tokens not dropped |
| Unreachable API | form again with `{'base': 'connection'}`, entry not updated, tokens not dropped |
| Valid credentials | `{'type': 'abort', 'reason': 'reauth_successful'}`, `data_updates` is exactly the two credentials, token store cleared |

The order matters in the failure rows: tokens must not be discarded until replacement credentials actually work, otherwise a typo would cost a working refresh token.

Also checked that `strings.json` and all three translations carry the new step with both field labels, keep the `{name}` placeholder, and define `reauth_successful`, and that the Danish and Portuguese additions are valid UTF-8 with the intended characters (`æ`, `á`, `ã`). Ruff passes and the package compiles. As with the previous PRs there is no booted Home Assistant, since `pytest-homeassistant-custom-component` is not installed and no tests are tracked in the repo.

## Note

`pt.json` had no `abort` section at all, so it gains one with just this reason. Its `already_configured` is still untranslated, which I left alone as out of scope.
