### PR TITLE
Move development onto Python 3.14 and Home Assistant 2026.7.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "nickknissen/hass-monta",
-    "image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/python:3-3.14-bookworm",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v7.0.0
           with:
-            python-version: "3.13"
+            python-version: "3.14"
             cache: "pip"
 
         - name: "Install requirements"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py310"
+target-version = "py314"
 
 [lint]
 select = [

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Monta",
     "filename": "monta.zip",
     "hide_default_branch": true,
-    "homeassistant": "2023.6.0",
+    "homeassistant": "2026.3.0",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.12.0
-homeassistant==2025.11.0
-ruff==0.16.0
-pip>=26.1.2,<26.2
+homeassistant==2026.7.4
+ruff==0.16.1
+pip>=26.2,<26.3
 debugpy==1.8.21
 monta==1.1.0


### PR DESCRIPTION
Routine dependency maintenance, plus the Python bump that the Home Assistant update forces.

## Changes

| File | From | To |
|---|---|---|
| `requirements.txt` | `homeassistant==2025.11.0` | `2026.7.4` |
| | `ruff==0.16.0` | `0.16.1` |
| | `pip>=26.1.2,<26.2` | `>=26.2,<26.3` |
| `.github/workflows/lint.yml` | `python-version: "3.13"` | `"3.14"` |
| `.devcontainer/devcontainer.json` | `python:1-3.13-bookworm` | `python:3-3.14-bookworm` |
| `.ruff.toml` | `target-version = "py310"` | `"py314"` |
| `hacs.json` | `homeassistant: 2023.6.0` | `2026.3.0` |

`colorlog`, `debugpy` and `monta` were already on their latest releases, as were all three GitHub Actions (`checkout@v7.0.1`, `setup-python@v7.0.0`, `action-gh-release@v3.0.2`). Dependabot had no open PRs.

## Why Python 3.14 is not optional

HA dropped 3.13 in 2026.3.0. At the 2026.7.4 tag its `pyproject.toml` has `requires-python = ">=3.14.2"` and lists `Programming Language :: Python :: 3.14` as its *only* classifier, and its CI builds the version matrix from a single `.python-version` of `3.14.5` with `ADDITIONAL_PYTHON_VERSIONS: "[]"`. Keeping 3.13 would have meant capping the dev pin at 2026.2.3.

The devcontainer changes image *line* as well as version because the `1-x` line never received a 3.14 variant; 3.14 tags start at `2-x`.

## Verification

- All 33 `homeassistant` imports in `custom_components/monta` resolve against the 2026.7.4 source tree.
- All 13 version-sensitive HA APIs the integration uses are present at the new 2026.3.0 floor.
- Every other pin has 3.14 support: `colorlog` and `monta` ship universal `py3` wheels, `debugpy` ships `cp314`, `ruff` ships platform wheels.
- `ruff check .` passes at `target-version = "py314"`; no new `UP` findings surfaced (`keep-runtime-typing = true` limits the blast radius).

## Reviewer notes

**The HACS floor jump is user-visible.** `2023.6.0` had drifted far below what the code needs, so it moves, but this does gate installs. The actual binding constraint is `_get_reauth_entry()` in the reauth flow, added in HA 2024.11.0. I picked 2026.3.0 rather than 2024.11.0 so the declared floor also implies Python 3.14, which is what makes `target-version = "py314"` correct: ruff reads that as the *oldest* supported Python, so a lower floor would have had ruff inviting rewrites that those users could not parse. Floor, dev pin, CI and lint target now all agree on 3.14. Worth a line in the release notes.

**The floor is asserted, not tested.** CI installs 2026.7.4 while the floor claims 2026.3.0, so nothing here would catch an API added in 2026.4 through 2026.7 that breaks a user on 2026.3.

**This PR is the first real execution of the new toolchain.** `tests/` contains no tests, so the `Lint` job is the only thing that actually performs the Python 3.14 plus HA 2026.7.4 install. My checks above are static (upstream metadata and wheel tags); please confirm Lint is green before merging.

**Not addressed:** the comment in `.github/dependabot.yml` still says the HA pin should match the `hacs.json` key. It doesn't (2026.7.4 vs 2026.3.0), and it never has. Happy to reword it here or separately.
