### PR TITLE
Recover from expired tokens instead of asking for credentials

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,3 +27,22 @@ jobs:
 
         - name: "Run"
           run: python3 -m ruff check .
+
+  tests:
+    name: "Tests"
+    runs-on: "ubuntu-latest"
+    steps:
+        - name: "Checkout the repository"
+          uses: "actions/checkout@v7.0.1"
+
+        - name: "Set up Python"
+          uses: actions/setup-python@v7.0.0
+          with:
+            python-version: "3.14"
+            cache: "pip"
+
+        - name: "Install requirements"
+          run: python3 -m pip install -r requirements.txt
+
+        - name: "Run"
+          run: python3 -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coverage.xml
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+# environments
+.venv

--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     LOGGER,
 )
 from .coordinator import (
+    MontaAuthGuard,
     MontaChargePointCoordinator,
     MontaTransactionCoordinator,
     MontaWalletCoordinator,
@@ -112,7 +113,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_remove_legacy_token_store(hass)
     store = async_get_token_store(hass, entry.entry_id)
 
-    # Get individual scan intervals for each data type
     scan_interval_charge_points = entry.options.get(
         CONF_SCAN_INTERVAL_CHARGE_POINTS,
         entry.data.get(
@@ -130,7 +130,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ),
     )
 
-    # Create API client shared by all coordinators
     client = MontaApiClient(
         client_id=entry.data[CONF_CLIENT_ID],
         client_secret=entry.data[CONF_CLIENT_SECRET],
@@ -138,24 +137,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         token_storage=HomeAssistantTokenStorage(store),
     )
 
-    # Create separate coordinators for each data type
+    # The coordinators share the client, so they share its tokens and must
+    # share the guard that replaces them.
+    auth = MontaAuthGuard(client)
+
     charge_point_coordinator = MontaChargePointCoordinator(
         hass=hass,
+        entry=entry,
         client=client,
+        auth=auth,
         scan_interval=scan_interval_charge_points,
     )
     wallet_coordinator = MontaWalletCoordinator(
         hass=hass,
+        entry=entry,
         client=client,
+        auth=auth,
         scan_interval=scan_interval_wallet,
     )
     transaction_coordinator = MontaTransactionCoordinator(
         hass=hass,
+        entry=entry,
         client=client,
+        auth=auth,
         scan_interval=scan_interval_transactions,
     )
 
-    # Store coordinators in a dictionary
     hass.data[DOMAIN][entry.entry_id] = {
         "charge_point": charge_point_coordinator,
         "wallet": wallet_coordinator,
@@ -163,7 +170,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
-    # Refresh all coordinators
     await charge_point_coordinator.async_config_entry_first_refresh()
     await wallet_coordinator.async_config_entry_first_refresh()
     await transaction_coordinator.async_config_entry_first_refresh()

--- a/custom_components/monta/__init__.py
+++ b/custom_components/monta/__init__.py
@@ -178,7 +178,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async_setup_services(hass)
 
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    # No update listener: the config and options flows ask for the reload
+    # themselves. Home Assistant deprecated pairing a listener with a flow
+    # that reloads, because between them the entry gets set up twice, and two
+    # setups mean two clients refreshing the same rotating Monta tokens.
 
     return True
 
@@ -197,9 +200,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Discard the entry's cached tokens when the entry is deleted."""
     await async_get_token_store(hass, entry.entry_id).async_remove()
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)

--- a/custom_components/monta/config_flow.py
+++ b/custom_components/monta/config_flow.py
@@ -190,6 +190,9 @@ class MontaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await async_get_token_store(
                     self.hass, entry.entry_id,
                 ).async_remove()
+                # Reloads even when the credentials came back unchanged,
+                # which is the common case: it is usually the cached tokens
+                # that went bad, not the client id and secret.
                 return self.async_update_reload_and_abort(
                     entry,
                     data_updates=user_input,
@@ -234,12 +237,13 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
         """Manage the options."""
         _errors = {}
         if user_input is not None:
-            # Only validate credentials if they were changed
-            if user_input.get(CONF_CLIENT_ID) != self.config_entry.data.get(
+            credentials_changed = user_input.get(
                 CONF_CLIENT_ID,
-            ) or user_input.get(CONF_CLIENT_SECRET) != self.config_entry.data.get(
+            ) != self.config_entry.data.get(CONF_CLIENT_ID) or user_input.get(
                 CONF_CLIENT_SECRET,
-            ):
+            ) != self.config_entry.data.get(CONF_CLIENT_SECRET)
+
+            if credentials_changed:
                 try:
                     await self._test_credentials(
                         client_id=user_input[CONF_CLIENT_ID],
@@ -256,39 +260,45 @@ class MontaOptionsFlowHandler(config_entries.OptionsFlow):
                     _errors["base"] = "unknown"
 
             if not _errors:
-                # Update the config entry data with new credentials if they changed
-                if user_input.get(CONF_CLIENT_ID) != self.config_entry.data.get(
-                    CONF_CLIENT_ID,
-                ) or user_input.get(CONF_CLIENT_SECRET) != self.config_entry.data.get(
-                    CONF_CLIENT_SECRET,
-                ):
+                if credentials_changed:
                     # Drop the cached tokens before the entry reloads with the
                     # new credentials, they belong to the old ones.
                     await async_get_token_store(
                         self.hass, self.config_entry.entry_id,
                     ).async_remove()
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry,
-                        data={
-                            CONF_CLIENT_ID: user_input[CONF_CLIENT_ID],
-                            CONF_CLIENT_SECRET: user_input[CONF_CLIENT_SECRET],
-                            CONF_SCAN_INTERVAL_CHARGE_POINTS: user_input.get(
-                                CONF_SCAN_INTERVAL_CHARGE_POINTS,
-                                DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
-                            ),
-                            CONF_SCAN_INTERVAL_WALLET: user_input.get(
-                                CONF_SCAN_INTERVAL_WALLET,
-                                DEFAULT_SCAN_INTERVAL_WALLET,
-                            ),
-                            CONF_SCAN_INTERVAL_TRANSACTIONS: user_input.get(
-                                CONF_SCAN_INTERVAL_TRANSACTIONS,
-                                DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
-                            ),
-                        },
-                    )
+                # Data and options are written together, and the reload is
+                # asked for here rather than from an update listener: pairing
+                # a listener with a flow that reloads is deprecated in Home
+                # Assistant, and set the entry up twice. Writing the options
+                # now also leaves async_create_entry below nothing to change.
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    options=user_input,
+                    data={
+                        CONF_CLIENT_ID: user_input[CONF_CLIENT_ID],
+                        CONF_CLIENT_SECRET: user_input[CONF_CLIENT_SECRET],
+                        CONF_SCAN_INTERVAL_CHARGE_POINTS: user_input.get(
+                            CONF_SCAN_INTERVAL_CHARGE_POINTS,
+                            DEFAULT_SCAN_INTERVAL_CHARGE_POINTS,
+                        ),
+                        CONF_SCAN_INTERVAL_WALLET: user_input.get(
+                            CONF_SCAN_INTERVAL_WALLET,
+                            DEFAULT_SCAN_INTERVAL_WALLET,
+                        ),
+                        CONF_SCAN_INTERVAL_TRANSACTIONS: user_input.get(
+                            CONF_SCAN_INTERVAL_TRANSACTIONS,
+                            DEFAULT_SCAN_INTERVAL_TRANSACTIONS,
+                        ),
+                    },
+                )
+                self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id,
+                )
                 return self.async_create_entry(title="", data=user_input)
 
-        # Build defaults from user_input -> options -> data
+        # Credentials are shown back as they were typed, since this form
+        # re-renders when the check on them fails. The intervals are read
+        # from what is saved: options first, then the entry's data.
         defaults = {
             CONF_CLIENT_ID: (user_input or {}).get(
                 CONF_CLIENT_ID,

--- a/custom_components/monta/coordinator.py
+++ b/custom_components/monta/coordinator.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from functools import partial
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -18,6 +20,8 @@ from monta.models import Charge, ChargePoint, ChargeState, Wallet, WalletTransac
 from .const import DOMAIN, LOGGER
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -28,6 +32,9 @@ CHARGES_PER_UPDATE = 100
 # change after these comes from a new charge, which by having a newer id is
 # guaranteed to appear in the bulk batch.
 CHARGE_TERMINAL_STATES = {ChargeState.STOPPED.value, ChargeState.COMPLETED.value}
+
+_DataT = TypeVar("_DataT")
+_T = TypeVar("_T")
 
 
 def _rate_limit_message(exception: MontaApiClientRateLimitError) -> str:
@@ -40,30 +47,136 @@ def _rate_limit_message(exception: MontaApiClientRateLimitError) -> str:
     return "Monta API rate limit hit; retrying on the next scheduled update"
 
 
-class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]]):
-    """Coordinator for charge point data."""
+class MontaAuthGuard:
+    """Replaces rejected tokens using the credentials already configured.
+
+    Monta access tokens live for an hour and refresh tokens rotate, so a 401
+    almost always means the cached tokens went stale rather than that the
+    client id and secret stopped working: those are long lived and the user
+    never has to touch them. Minting a new token set from the stored
+    credentials therefore settles nearly every authentication failure without
+    involving the user at all.
+
+    One guard is shared by the coordinators of a config entry, because they
+    share the client and its tokens. Without that, a single expiry would have
+    all three of them minting tokens at once and invalidating each other's.
+    """
+
+    def __init__(self, client: MontaApiClient) -> None:
+        """Initialize."""
+        self._client = client
+        self._lock = asyncio.Lock()
+        self._generation = 0
+
+    @property
+    def generation(self) -> int:
+        """Return a counter identifying the current set of tokens."""
+        return self._generation
+
+    async def async_reauthenticate(self, generation: int) -> None:
+        """Mint a new token set, unless another caller just did so.
+
+        Pass the generation read before the failing request: if it no longer
+        matches, the tokens that request failed with have already been
+        replaced and retrying is enough.
+        """
+        async with self._lock:
+            if generation != self._generation:
+                return
+            await self._client.async_authenticate()
+            self._generation += 1
+
+
+class MontaCoordinator(DataUpdateCoordinator[_DataT]):
+    """Shared API error handling for the Monta coordinators."""
 
     config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        client: MontaApiClient,
+        auth: MontaAuthGuard,
+        name: str,
+        scan_interval: int,
+    ) -> None:
+        """Initialize."""
+        self.client = client
+        self._auth = auth
+        super().__init__(
+            hass=hass,
+            logger=LOGGER,
+            name=name,
+            config_entry=entry,
+            update_interval=timedelta(seconds=scan_interval),
+        )
+
+    async def _async_call_api(
+        self,
+        action: Callable[[], Coroutine[Any, Any, _T]],
+    ) -> _T:
+        """Run an API call, translating the library's errors for the caller.
+
+        A rejected token is re-minted from the configured credentials and the
+        call retried once, so only credentials the API itself refuses reach
+        ConfigEntryAuthFailed and ask the user to reauthenticate.
+
+        The action can be run twice, so it has to be safe to repeat.
+        """
+        generation = self._auth.generation
+        try:
+            try:
+                return await action()
+            except MontaApiClientAuthenticationError:
+                LOGGER.debug(
+                    "%s: Monta rejected the access token, re-authenticating "
+                    "with the configured credentials",
+                    self.name,
+                )
+                await self._auth.async_reauthenticate(generation)
+                return await action()
+        except MontaApiClientAuthenticationError as exception:
+            # Raised by the re-authentication or by the retry after it: the
+            # client id and secret themselves are no longer accepted, which
+            # only the user can put right.
+            raise ConfigEntryAuthFailed(exception) from exception
+        except MontaApiClientRateLimitError as exception:
+            raise UpdateFailed(_rate_limit_message(exception)) from exception
+        except MontaApiClientError as exception:
+            raise UpdateFailed(exception) from exception
+
+
+class MontaChargePointCoordinator(MontaCoordinator[dict[int, ChargePoint]]):
+    """Coordinator for charge point data."""
+
     data: dict[int, ChargePoint]
 
     def __init__(
         self,
         hass: HomeAssistant,
+        entry: ConfigEntry,
         client: MontaApiClient,
+        auth: MontaAuthGuard,
         scan_interval: int,
     ) -> None:
         """Initialize."""
-        self.client = client
         self._backfilled_charge_points: set[int] = set()
         super().__init__(
             hass=hass,
-            logger=LOGGER,
+            entry=entry,
+            client=client,
+            auth=auth,
             name=f"{DOMAIN}_charge_points",
-            update_interval=timedelta(seconds=scan_interval),
+            scan_interval=scan_interval,
         )
 
     async def _async_update_data(self) -> dict[int, ChargePoint]:
-        """Update charge point data via library.
+        """Update charge point data via library."""
+        return await self._async_call_api(self._async_fetch_charge_points)
+
+    async def _async_fetch_charge_points(self) -> dict[int, ChargePoint]:
+        """Fetch every charge point together with its charges.
 
         Uses two requests per cycle regardless of charger count: one
         paginated charge-point fetch and one bulk charges fetch, so accounts
@@ -76,17 +189,10 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
         charge never goes stale, since any state change comes from a newer
         charge that is guaranteed to appear in the batch.
         """
-        try:
-            charge_points = await self.client.async_get_all_charge_points()
-            charges = await self.client.async_get_charges(
-                per_page=CHARGES_PER_UPDATE,
-            )
-        except MontaApiClientAuthenticationError as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
-        except MontaApiClientRateLimitError as exception:
-            raise UpdateFailed(_rate_limit_message(exception)) from exception
-        except MontaApiClientError as exception:
-            raise UpdateFailed(exception) from exception
+        charge_points = await self.client.async_get_all_charge_points()
+        charges = await self.client.async_get_charges(
+            per_page=CHARGES_PER_UPDATE,
+        )
 
         charges_by_charge_point: dict[int, list[Charge]] = {}
         for charge in charges:
@@ -110,11 +216,10 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
             elif charge_point_id not in self._backfilled_charge_points:
                 needs_fetch.append(charge_point_id)
 
+        backfilled: set[int] = set()
         for charge_point_id in needs_fetch:
             try:
                 fetched = await self.client.async_get_charges(charge_point_id)
-            except MontaApiClientAuthenticationError as exception:
-                raise ConfigEntryAuthFailed(exception) from exception
             except MontaApiClientRateLimitError:
                 # Keep the bulk data already gathered; chargers not yet
                 # fetched stay pending and are retried next cycle.
@@ -124,10 +229,14 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
                     charge_point_id,
                 )
                 break
-            except MontaApiClientError as exception:
-                raise UpdateFailed(exception) from exception
-            self._backfilled_charge_points.add(charge_point_id)
+            backfilled.add(charge_point_id)
             charge_points[charge_point_id].charges = fetched
+
+        # Recorded only once the whole fetch has come through, because a
+        # rejected token sends this method back to the top: a charger marked
+        # on the abandoned attempt would be taken for done on the retry and
+        # keep the empty charges it was left with, for good.
+        self._backfilled_charge_points |= backfilled
 
         return charge_points
 
@@ -139,94 +248,76 @@ class MontaChargePointCoordinator(DataUpdateCoordinator[dict[int, ChargePoint]])
 
     async def async_start_charge(self, charge_point_id: int) -> Charge:
         """Start a charge."""
-        try:
-            return await self.client.async_start_charge(charge_point_id)
-        except MontaApiClientAuthenticationError as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
-        except MontaApiClientRateLimitError as exception:
-            raise UpdateFailed(_rate_limit_message(exception)) from exception
-        except MontaApiClientError as exception:
-            raise UpdateFailed(exception) from exception
+        return await self._async_call_api(
+            partial(self.client.async_start_charge, charge_point_id),
+        )
 
     async def async_stop_charge(self, charge_point_id: int) -> Charge:
         """Stop a charge."""
-        try:
-            charges = await self.client.async_get_charges(charge_point_id)
-            if not charges:
-                msg = f"No active charges found for charge point {charge_point_id}"
-                raise UpdateFailed(
-                    msg,
-                )
-            return await self.client.async_stop_charge(charges[0].id)
-        except MontaApiClientAuthenticationError as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
-        except MontaApiClientRateLimitError as exception:
-            raise UpdateFailed(_rate_limit_message(exception)) from exception
-        except MontaApiClientError as exception:
-            raise UpdateFailed(exception) from exception
+        return await self._async_call_api(
+            partial(self._async_stop_latest_charge, charge_point_id),
+        )
+
+    async def _async_stop_latest_charge(self, charge_point_id: int) -> Charge:
+        """Stop whichever charge the charge point is running."""
+        charges = await self.client.async_get_charges(charge_point_id)
+        if not charges:
+            msg = f"No active charges found for charge point {charge_point_id}"
+            raise UpdateFailed(msg)
+        return await self.client.async_stop_charge(charges[0].id)
 
 
-class MontaWalletCoordinator(DataUpdateCoordinator[Wallet]):
+class MontaWalletCoordinator(MontaCoordinator[Wallet]):
     """Coordinator for wallet data."""
 
-    config_entry: ConfigEntry
     data: Wallet
 
     def __init__(
         self,
         hass: HomeAssistant,
+        entry: ConfigEntry,
         client: MontaApiClient,
+        auth: MontaAuthGuard,
         scan_interval: int,
     ) -> None:
         """Initialize."""
-        self.client = client
         super().__init__(
             hass=hass,
-            logger=LOGGER,
+            entry=entry,
+            client=client,
+            auth=auth,
             name=f"{DOMAIN}_wallet",
-            update_interval=timedelta(seconds=scan_interval),
+            scan_interval=scan_interval,
         )
 
     async def _async_update_data(self) -> Wallet:
         """Update wallet data via library."""
-        try:
-            return await self.client.async_get_personal_wallet()
-        except MontaApiClientAuthenticationError as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
-        except MontaApiClientRateLimitError as exception:
-            raise UpdateFailed(_rate_limit_message(exception)) from exception
-        except MontaApiClientError as exception:
-            raise UpdateFailed(exception) from exception
+        return await self._async_call_api(self.client.async_get_personal_wallet)
 
 
-class MontaTransactionCoordinator(DataUpdateCoordinator[list[WalletTransaction]]):
+class MontaTransactionCoordinator(MontaCoordinator[list[WalletTransaction]]):
     """Coordinator for transaction data."""
 
-    config_entry: ConfigEntry
     data: list[WalletTransaction]
 
     def __init__(
         self,
         hass: HomeAssistant,
+        entry: ConfigEntry,
         client: MontaApiClient,
+        auth: MontaAuthGuard,
         scan_interval: int,
     ) -> None:
         """Initialize."""
-        self.client = client
         super().__init__(
             hass=hass,
-            logger=LOGGER,
+            entry=entry,
+            client=client,
+            auth=auth,
             name=f"{DOMAIN}_transactions",
-            update_interval=timedelta(seconds=scan_interval),
+            scan_interval=scan_interval,
         )
 
     async def _async_update_data(self) -> list[WalletTransaction]:
         """Update transaction data via library."""
-        try:
-            return await self.client.async_get_wallet_transactions()
-        except MontaApiClientAuthenticationError as exception:
-            raise ConfigEntryAuthFailed(exception) from exception
-        except MontaApiClientRateLimitError as exception:
-            raise UpdateFailed(_rate_limit_message(exception)) from exception
-        except MontaApiClientError as exception:
-            raise UpdateFailed(exception) from exception
+        return await self._async_call_api(self.client.async_get_wallet_transactions)

--- a/custom_components/monta/manifest.json
+++ b/custom_components/monta/manifest.json
@@ -14,7 +14,7 @@
     "monta"
   ],
   "requirements": [
-    "monta==1.1.0"
+    "monta==1.2.0"
   ],
   "version": "1.3.0"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ ruff==0.16.1
 pip>=26.2,<26.3
 debugpy==1.8.21
 monta==1.1.0
+pytest==9.0.3
+pytest-homeassistant-custom-component==0.13.348

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ homeassistant==2026.7.4
 ruff==0.16.1
 pip>=26.2,<26.3
 debugpy==1.8.21
-monta==1.1.0
+monta==1.2.0
 pytest==9.0.3
 pytest-homeassistant-custom-component==0.13.348

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Monta integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,141 @@
+"""Fixtures for the Monta tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from monta import MontaApiClientAuthenticationError
+from monta.models import TokenResponse
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.monta.const import DOMAIN
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+CLIENT_ID = "client-id"
+CLIENT_SECRET = "client-secret"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(
+    enable_custom_integrations: None,  # noqa: ARG001
+) -> None:
+    """Load the integration from custom_components."""
+    return
+
+
+class FakeMontaClient:
+    """Stands in for MontaApiClient, with its token behaviour.
+
+    Monta hands out access tokens that last an hour and rotates the refresh
+    token, so the interesting states are "the cached tokens went stale" and
+    "the client id and secret are no longer accepted". They are separate
+    switches here because the integration is meant to tell them apart.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with tokens the API accepts."""
+        self.tokens_accepted = True
+        self.credentials_accepted = True
+        self.authenticate_calls = 0
+        self.request_calls = 0
+
+    def expire_tokens(self) -> None:
+        """Make the API reject the tokens the client holds."""
+        self.tokens_accepted = False
+
+    async def async_authenticate(self) -> None:
+        """Mint a token set from the client id and secret."""
+        self.authenticate_calls += 1
+        if not self.credentials_accepted:
+            raise MontaApiClientAuthenticationError("Invalid credentials")
+        self.tokens_accepted = True
+
+    def _request(self) -> None:
+        self.request_calls += 1
+        if not self.tokens_accepted:
+            raise MontaApiClientAuthenticationError("Invalid credentials")
+
+    async def async_get_all_charge_points(
+        self, per_page: int = 100,  # noqa: ARG002
+    ) -> dict[int, Any]:
+        """Return no charge points, which keeps the platforms out of it."""
+        self._request()
+        return {}
+
+    async def async_get_charges(self, *args: Any, **kwargs: Any) -> list[Any]:  # noqa: ANN401, ARG002
+        """Return no charges."""
+        self._request()
+        return []
+
+    async def async_get_personal_wallet(self) -> Any:  # noqa: ANN401
+        """Return a wallet."""
+        self._request()
+        return object()
+
+    async def async_get_wallet_transactions(self) -> list[Any]:
+        """Return no transactions."""
+        self._request()
+        return []
+
+
+def token_response() -> TokenResponse:
+    """Return the token a successful credential check produces."""
+    now = datetime.now(UTC)
+    return TokenResponse(
+        access_token="access",
+        access_token_expiration_date=now + timedelta(hours=1),
+        refresh_token="refresh",
+        refresh_token_expiration_date=now + timedelta(days=31),
+        user_id="user-1",
+    )
+
+
+@pytest.fixture
+def config_entry() -> MockConfigEntry:
+    """Return a configured Monta account."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Monta account user-1",
+        data={"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET},
+    )
+
+
+@pytest.fixture
+def clients() -> list[FakeMontaClient]:
+    """Collect every client the integration builds.
+
+    The integration builds exactly one per setup, so the length of this list
+    is the number of times the entry has been set up.
+    """
+    return []
+
+
+@pytest.fixture
+def mock_client(clients: list[FakeMontaClient]):  # noqa: ANN201
+    """Patch in the fake client and record each one built."""
+
+    def build(**_: Any) -> FakeMontaClient:
+        client = FakeMontaClient()
+        clients.append(client)
+        return client
+
+    with patch(
+        "custom_components.monta.MontaApiClient", side_effect=build,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_credential_check():  # noqa: ANN201
+    """Accept whatever credentials a config flow validates."""
+    with patch(
+        "custom_components.monta.config_flow.MontaApiClient",
+    ) as mock:
+        mock.return_value.async_request_token = AsyncMock(
+            return_value=token_response(),
+        )
+        yield mock

--- a/tests/test_auth_recovery.py
+++ b/tests/test_auth_recovery.py
@@ -1,16 +1,20 @@
 """Tests for what the integration does when Monta rejects a token.
 
-Covers the first half of issue #321: an expired access token must not turn
-into a request for the user's credentials.
+Covers the two halves of issue #321: an expired access token must not turn
+into a request for the user's credentials, and finishing a flow must not set
+the entry up twice over the same rotating tokens.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.data_entry_flow import FlowResultType
 from monta import MontaApiClientAuthenticationError
 
 from custom_components.monta.const import DOMAIN
@@ -49,6 +53,26 @@ async def setup_entry(hass: HomeAssistant, entry: MockConfigEntry) -> None:
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+
+
+def assert_entry_survived(
+    entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Assert the entry came back up with nothing thrown on the way.
+
+    An update listener is what reloads an entry from outside Home Assistant's
+    own setup, and such a reload raises out of
+    async_config_entry_first_refresh: the coordinators are built with no
+    config entry in context. Nobody awaits that task, so the exception only
+    reaches the log once it is garbage collected, which is too late to catch
+    here reliably. The absence of the listener is the part worth pinning.
+    """
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.update_listeners == []
+    assert [
+        record for record in caplog.records if record.levelno >= logging.ERROR
+    ] == []
 
 
 async def test_expired_tokens_recover_without_asking_the_user(
@@ -193,3 +217,101 @@ async def test_a_refused_backfill_does_not_strand_the_chargers_before_it(
     assert client.targeted == [1, 2, 1, 2]
     assert coordinator.data[1].charges
     assert coordinator.data[2].charges
+
+
+async def test_reauth_sets_the_entry_up_once(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    clients: list[FakeMontaClient],
+    mock_client: None,  # noqa: ARG001
+    mock_credential_check: None,  # noqa: ARG001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Finishing reauthentication reloads the entry exactly once.
+
+    A second, concurrent setup would give the account two clients refreshing
+    the same rotating tokens, and whichever refreshed second would be handed
+    a 401 an hour later.
+    """
+    await setup_entry(hass, config_entry)
+    assert len(clients) == 1
+
+    result = await config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_CLIENT_ID: "new-id", CONF_CLIENT_SECRET: "new-secret"},
+    )
+    await hass.async_block_till_done()
+
+    assert_entry_survived(config_entry, caplog)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert config_entry.data[CONF_CLIENT_ID] == "new-id"
+    assert len(clients) == 2
+
+
+async def test_reauth_reloads_even_when_the_credentials_are_unchanged(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    clients: list[FakeMontaClient],
+    mock_client: None,  # noqa: ARG001
+    mock_credential_check: None,  # noqa: ARG001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Resubmitting the same credentials still reloads the entry.
+
+    The usual reason a user reaches this form is stale tokens, so they will
+    often retype what is already configured. Leaving the entry untouched
+    would leave it broken with nothing to show for the trip.
+    """
+    await setup_entry(hass, config_entry)
+
+    result = await config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CLIENT_ID: config_entry.data[CONF_CLIENT_ID],
+            CONF_CLIENT_SECRET: config_entry.data[CONF_CLIENT_SECRET],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert_entry_survived(config_entry, caplog)
+    assert result["type"] is FlowResultType.ABORT
+    assert len(clients) == 2
+
+
+async def test_options_flow_sets_the_entry_up_once(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    clients: list[FakeMontaClient],
+    mock_client: None,  # noqa: ARG001
+    mock_credential_check: None,  # noqa: ARG001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Saving the options reloads the entry exactly once.
+
+    New credentials are the case that used to write the entry twice, once for
+    the data and once for the options, and so set it up twice.
+    """
+    await setup_entry(hass, config_entry)
+    assert len(clients) == 1
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_CLIENT_ID: "new-id",
+            CONF_CLIENT_SECRET: "new-secret",
+            "scan_interval_charge_points": 300,
+            "scan_interval_wallet": 600,
+            "scan_interval_transactions": 600,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert_entry_survived(config_entry, caplog)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.data[CONF_CLIENT_ID] == "new-id"
+    assert config_entry.options["scan_interval_charge_points"] == 300
+    assert len(clients) == 2

--- a/tests/test_auth_recovery.py
+++ b/tests/test_auth_recovery.py
@@ -1,0 +1,195 @@
+"""Tests for what the integration does when Monta rejects a token.
+
+Covers the first half of issue #321: an expired access token must not turn
+into a request for the user's credentials.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from monta import MontaApiClientAuthenticationError
+
+from custom_components.monta.const import DOMAIN
+from custom_components.monta.coordinator import (
+    MontaAuthGuard,
+    MontaChargePointCoordinator,
+)
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from homeassistant.core import HomeAssistant
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from .conftest import FakeMontaClient
+
+
+@pytest.fixture(autouse=True)
+def no_platforms():  # noqa: ANN201
+    """Keep the entities out of these tests, they are about the entry."""
+    with patch("custom_components.monta.PLATFORMS", []):
+        yield
+
+
+def reauth_flows(hass: HomeAssistant) -> list[dict]:
+    """Return the reauthentication flows waiting for the user."""
+    return [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"].get("source") == SOURCE_REAUTH
+    ]
+
+
+async def setup_entry(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set up a config entry and wait for it to settle."""
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_expired_tokens_recover_without_asking_the_user(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    clients: list[FakeMontaClient],
+    mock_client: None,  # noqa: ARG001
+) -> None:
+    """An expired access token is replaced from the configured credentials.
+
+    Monta access tokens last an hour. Expiry says nothing about the client id
+    and secret, so it must not surface as "your credentials are no longer
+    valid" once an hour, which is what issue #321 reports.
+    """
+    await setup_entry(hass, config_entry)
+    client = clients[0]
+
+    client.expire_tokens()
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["charge_point"]
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.last_update_success
+    assert client.authenticate_calls == 1
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert reauth_flows(hass) == []
+
+
+async def test_expired_tokens_are_replaced_once_for_all_coordinators(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    clients: list[FakeMontaClient],
+    mock_client: None,  # noqa: ARG001
+) -> None:
+    """The three coordinators share a client, so they share one new token set.
+
+    Letting each of them authenticate on its own would have them rotating the
+    tokens out from under each other.
+    """
+    await setup_entry(hass, config_entry)
+    client = clients[0]
+    coordinators = hass.data[DOMAIN][config_entry.entry_id]
+
+    client.expire_tokens()
+    for coordinator in coordinators.values():
+        await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert all(
+        coordinator.last_update_success for coordinator in coordinators.values()
+    )
+    assert client.authenticate_calls == 1
+
+
+async def test_rejected_credentials_do_ask_the_user(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    clients: list[FakeMontaClient],
+    mock_client: None,  # noqa: ARG001
+) -> None:
+    """Credentials the API itself refuses are worth interrupting the user for."""
+    await setup_entry(hass, config_entry)
+    client = clients[0]
+
+    client.expire_tokens()
+    client.credentials_accepted = False
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["charge_point"]
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert not coordinator.last_update_success
+    assert len(reauth_flows(hass)) == 1
+
+
+class BackfilledChargePoint:
+    """A charge point as the coordinator handles it: a bag of charges."""
+
+    def __init__(self) -> None:
+        """Initialize with no charges, as the API returns it."""
+        self.charges: list[Any] = []
+
+
+class BackfillClient:
+    """A client whose bulk batch never covers its charge points.
+
+    Both charge points therefore need a targeted fetch, and the second of
+    those is refused, which is what sends the whole update through the retry.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with the second targeted fetch set to be refused."""
+        self.targeted: list[int] = []
+        self._refuse_targeted = True
+
+    async def async_authenticate(self) -> None:
+        """Mint a token set the API accepts."""
+
+    async def async_get_all_charge_points(
+        self, per_page: int = 100,  # noqa: ARG002
+    ) -> dict[int, BackfilledChargePoint]:
+        """Return two charge points, neither of them in the bulk batch."""
+        return {1: BackfilledChargePoint(), 2: BackfilledChargePoint()}
+
+    async def async_get_charges(
+        self,
+        charge_point_id: int | None = None,
+        per_page: int | None = None,  # noqa: ARG002
+    ) -> list[Any]:
+        """Return an empty bulk batch, or a charge for a targeted fetch."""
+        if charge_point_id is None:
+            return []
+        self.targeted.append(charge_point_id)
+        if charge_point_id == 2 and self._refuse_targeted:
+            self._refuse_targeted = False
+            raise MontaApiClientAuthenticationError("Invalid credentials")
+        return [object()]
+
+
+async def test_a_refused_backfill_does_not_strand_the_chargers_before_it(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Chargers backfilled before a 401 are backfilled again on the retry.
+
+    Re-minting the token runs the whole update again, so anything the
+    abandoned attempt recorded as backfilled would be taken for done the
+    second time round and keep the empty charges it was left with.
+    """
+    config_entry.add_to_hass(hass)
+    client = BackfillClient()
+    coordinator = MontaChargePointCoordinator(
+        hass=hass,
+        entry=config_entry,
+        client=client,
+        auth=MontaAuthGuard(client),
+        scan_interval=300,
+    )
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert client.targeted == [1, 2, 1, 2]
+    assert coordinator.data[1].charges
+    assert coordinator.data[2].charges


### PR DESCRIPTION
Fixes #321.

## Why the credentials prompt was wrong

Monta uses client credentials: a long lived client id and secret stored on the config entry. They do not expire. What expires is the access token, [within an hour](https://docs.public-api.monta.com/), which means every entry meets a 401 roughly once an hour.

Both halves of that were treated as if the user's credentials had gone bad.

The coordinators turned every `MontaApiClientAuthenticationError` straight into `ConfigEntryAuthFailed`, which is Home Assistant's "ask the user" signal. The credentials were still perfectly good; it was the cached tokens that had expired, and the integration was already holding everything needed to replace them.

The reauth flow added in #319 then made it recur. Pairing an update listener with a config flow that reloads sets the entry up twice, which Home Assistant [deprecated in 2026.6](https://developers.home-assistant.io/blog/2026/05/07/config-entry-listener-together-with-reloading-methods/) and reports against this integration, exactly as quoted in #321:

```
Detected that custom integration 'monta' has an update listener and should use it for
scheduling a reload. This will stop working in Home Assistant 2026.12.0
```

Two setups mean two clients over one entry's rotating tokens. Whichever refreshed second was handed a 401 an hour later, the user reauthenticated, and that reauth set the entry up twice again. Hence "every hour or so", and hence resetting the credentials appearing to help: it is the only path that clears the token store.

The rotation is the part worth spelling out, because `monta==1.1.0` has nothing to catch it. `_is_refresh_token_valid` only checks the stored expiry, which is ~30 days out, so the token looks fine locally after a sibling client has rotated it away server-side. `_async_get_access_token` then posts it to `auth/refresh` with no `try`/`except` at all ([1.1.0 `client.py:418-437`](https://pypi.org/project/monta/1.1.0/)), so the 401 propagates untouched. The access token's own hour of validity is what delays the collision until the first refresh boundary.

## The listener also crashes on current Home Assistant

Not just a future break. Reconfiguring on 2026.8 produces this immediately:

```
Error doing job: Task exception was never retrieved (task: None)
  File "/config/custom_components/monta/__init__.py", line 199, in async_reload_entry
    await async_setup_entry(hass, entry)
  File "/config/custom_components/monta/__init__.py", line 167, in async_setup_entry
    await charge_point_coordinator.async_config_entry_first_refresh()
homeassistant.exceptions.ConfigEntryError: Detected code that uses
`async_config_entry_first_refresh`, which is only supported for coordinators with a config entry
```

`async_reload_entry` calls `async_setup_entry` directly from a listener task, so the `config_entries.current_entry` ContextVar that a coordinator falls back on (`update_coordinator.py:95-110`) is unset, `self.config_entry` is `None`, and the first refresh raises (`:334`). Passing `config_entry=` explicitly would not have saved that path either — the next guard requires the entry to be in `SETUP_IN_PROGRESS`, and during a manual reload it is `LOADED`.

Because `async_reload_entry` unloads before it sets up, the failure leaves platforms torn down and coordinators in `hass.data` that never refreshed, all racing Home Assistant's own scheduled reload. Nobody awaits the task, so the exception only reaches the log when it is garbage collected.

## What changed

**`coordinator.py`** — a new `MontaAuthGuard` and a `MontaCoordinator` base carrying `_async_call_api`, which the three coordinators and the start/stop charge calls all route through. A rejected token is re-minted from the credentials already on the entry and the call retried once; only credentials the API itself refuses reach `ConfigEntryAuthFailed`. The guard is shared per entry, because the coordinators share a client and its tokens, and a generation counter means a simultaneous expiry mints one token set rather than three that rotate each other away. Rate limit and generic error translation moved here too, instead of being repeated in six `try`/`except` blocks.

Because `_async_call_api` may run its action twice, `_async_fetch_charge_points` had to become safe to repeat, and was not: it recorded chargers in `_backfilled_charge_points` as it went, so a 401 partway through the targeted fetches would have the retry skip everything the abandoned attempt had already marked. Those chargers keep the empty charges they were left with, permanently — the set is the "backfill once, ever" marker. The ids are now committed only once the whole fetch comes through.

**`__init__.py`** — the update listener is gone, and with it `async_reload_entry`. Coordinators are handed `config_entry` explicitly rather than having it inferred from a ContextVar.

**`config_flow.py`** — reauth keeps `async_update_reload_and_abort`, which no longer warns now that no listener is registered, and which reloads even when the entry is unchanged. That last part matters: someone who reaches this form because of stale tokens will usually retype the credentials they already have, and a non-reloading update would leave them with a broken entry and nothing to show for the trip. The options flow writes data and options in one update and asks for the reload itself, rather than firing the listener twice.

**`manifest.json` / `requirements.txt`** — `monta==1.2.0`, which recovers from refused tokens on its own: a refused refresh token falls back to the client credentials, and a request refused with a 401 is retried with a replacement token. That is the cleaner home for the fix, and with it underneath the guard here should rarely have anything left to catch. It stays as the backstop it was meant to be, since re-authenticating from the credentials on the config entry is one level above anything the library can do for itself.

## Tests

Seven tests against real Home Assistant, via `pytest-homeassistant-custom-component`, wired into CI.

Run against `main`, the three flow tests fail on `assert entry.update_listeners == []` and on the client count — three clients built over one entry where there should be two, which is the double setup itself. Those runs also surface the `ConfigEntryError` above. It is deliberately not asserted on: `Task exception was never retrieved` is emitted when asyncio garbage collects the abandoned task, so whether it lands inside the test body is timing dependent. The absence of the listener is the deterministic thing to pin, and it is the precondition for the crash.

The token tests cover the other half: an expired access token recovers without a prompt, one token set is minted between the three coordinators rather than three that rotate each other away, and credentials the API genuinely refuses still prompt. The backfill test drives a 401 partway through the targeted fetches and asserts every charger still ends the cycle with its charges.

Known gap: the flow tests patch `PLATFORMS` to `[]`, so nothing covers what entities do across a reload.

## Commits

Four, each green on its own:

1. `686919d` the pytest harness and fixtures
2. `9707ded` the auth guard, the shared coordinator base, and the backfill fix
3. `afb2b33` dropping the update listener, flows asking for their own reload
4. `2bdac45` pinning `monta==1.2.0`

## Follow-ups filed

#323 (the guard hands its generation counter to the caller, and is misnamed), #324 (wallet and transaction coordinators differ only by their name), #325 (CONTRIBUTING, `scripts/test`, splitting the tests job out of `lint.yml`).

## Worth checking with the reporter

Their system health shows `ntp_synchronized | false`. Access token validity is judged by comparing a server issued expiry against the local clock with a 300 second margin (`PREEMPTIVE_REFRESH_TTL_IN_SECONDS`), so a clock more than five minutes slow produces this same hourly failure independently of everything above. This change makes that case recover quietly rather than nag, but it would be good to know.
